### PR TITLE
[ReceiptView] add camera and gallery access

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		9072AFDB2BE9C47000DE6FEB /* FairShareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFDA2BE9C47000DE6FEB /* FairShareTests.swift */; };
 		9072AFE52BE9C47000DE6FEB /* FairShareUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFE42BE9C47000DE6FEB /* FairShareUITests.swift */; };
 		9072AFE72BE9C47000DE6FEB /* FairShareUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFE62BE9C47000DE6FEB /* FairShareUITestsLaunchTests.swift */; };
+		909E69942C02A5C7009D00D6 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E69932C02A5C7009D00D6 /* CameraView.swift */; };
 		90F5749F2BF93BCC005A9A2E /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F5749E2BF93BCC005A9A2E /* MainTabView.swift */; };
 		90FB96152BF020490061E83D /* ReceiptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FB96142BF020490061E83D /* ReceiptModel.swift */; };
 		90FB96172BF023340061E83D /* Date+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FB96162BF023340061E83D /* Date+Helper.swift */; };
@@ -86,6 +87,7 @@
 		9072AFE02BE9C47000DE6FEB /* FairShareUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FairShareUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9072AFE42BE9C47000DE6FEB /* FairShareUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FairShareUITests.swift; sourceTree = "<group>"; };
 		9072AFE62BE9C47000DE6FEB /* FairShareUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FairShareUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		909E69932C02A5C7009D00D6 /* CameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraView.swift; sourceTree = "<group>"; };
 		90F5749E2BF93BCC005A9A2E /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		90FB96142BF020490061E83D /* ReceiptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptModel.swift; sourceTree = "<group>"; };
 		90FB96162BF023340061E83D /* Date+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Helper.swift"; sourceTree = "<group>"; };
@@ -210,6 +212,7 @@
 				9072AFC62BE9C46E00DE6FEB /* ContentView.swift */,
 				902C01F92BF017660004B01A /* ReceiptView.swift */,
 				90FB96182BF029190061E83D /* NewReceiptView.swift */,
+				909E69932C02A5C7009D00D6 /* CameraView.swift */,
 				90FB96262BF030B20061E83D /* LoginView.swift */,
 				90F5749E2BF93BCC005A9A2E /* MainTabView.swift */,
 				90FB96282BF0321C0061E83D /* InputView.swift */,
@@ -438,6 +441,7 @@
 				90FB962D2BF0753E0061E83D /* ProfileView.swift in Sources */,
 				9072AFC72BE9C46E00DE6FEB /* ContentView.swift in Sources */,
 				90FB96172BF023340061E83D /* Date+Helper.swift in Sources */,
+				909E69942C02A5C7009D00D6 /* CameraView.swift in Sources */,
 				9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */,
 				902C01FA2BF017660004B01A /* ReceiptView.swift in Sources */,
 				90FB96272BF030B20061E83D /* LoginView.swift in Sources */,
@@ -608,6 +612,7 @@
 				DEVELOPMENT_TEAM = FSUP887MQU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app needs to capture images of your receipt";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -638,6 +643,7 @@
 				DEVELOPMENT_TEAM = FSUP887MQU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app needs to capture images of your receipt";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/FairShare/UI/CameraView.swift
+++ b/FairShare/UI/CameraView.swift
@@ -1,0 +1,44 @@
+//
+//  CameraView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 5/25/24.
+//
+
+import PhotosUI
+import SwiftUI
+
+struct CameraView: UIViewControllerRepresentable {
+	@Binding var selectedImage: UIImage?
+	@Environment(\.presentationMode) var isPresented
+
+	func makeUIViewController(context: Context) -> UIImagePickerController {
+		let imagePicker = UIImagePickerController()
+		imagePicker.sourceType = .camera
+		imagePicker.allowsEditing = true
+		imagePicker.delegate = context.coordinator
+		return imagePicker
+	}
+
+	func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+
+	}
+
+	func makeCoordinator() -> Coordinator {
+		return Coordinator(picker: self)
+	}
+}
+
+class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+	var picker: CameraView
+
+	init(picker: CameraView) {
+		self.picker = picker
+	}
+
+	func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+		guard let selectedImage = info[.originalImage] as? UIImage else { return }
+		self.picker.selectedImage = selectedImage
+		self.picker.isPresented.wrappedValue.dismiss()
+	}
+}

--- a/FairShare/UI/ReceiptView.swift
+++ b/FairShare/UI/ReceiptView.swift
@@ -5,34 +5,73 @@
 //  Created by Stephanie Ramirez on 5/11/24.
 //
 
-import SwiftUI
 import Firebase
+import PhotosUI
+import SwiftUI
 
 struct ReceiptView: View {
-	@EnvironmentObject var viewModel: AuthViewModel
-	@State var showActionSheet = false
+	@EnvironmentObject var authViewModel: AuthViewModel
+	@State private var showActionSheet = false
+	@State private var showCamera = false
+	@State private var showGallery = false
+	@State private var selectedImage: UIImage?
+	@State private var selectedItem: PhotosPickerItem?
+	@State private var imageToDisplay: Image?
 
 	var body: some View {
 		NavigationStack {
-			List(viewModel.receipts, id: \.id) { receipt in
+			//TODO: remove imageToDisplay. For testing purposes only.
+			imageToDisplay?
+				.resizable()
+				.scaledToFit()
+				.frame(width: 300, height: 300)
+
+			List(authViewModel.receipts, id: \.id) { receipt in
 				Text(receipt.date)
 			}
 			.navigationTitle("Previous Receipts")
 			.toolbar {
 				ToolbarItem(placement: .topBarTrailing) {
 					Button {
-						showActionSheet = true
+						showActionSheet.toggle()
 					} label: {
-						Label(title: { Text("Label") }, icon: { Image(systemName: "plus") })
+						Label(title: {}, icon: { Image(systemName: "plus") })
 					}
 				}
 			}
 			.confirmationDialog("New Receipt", isPresented: $showActionSheet) {
-				Button("Camera") { print("Camera") }
-				Button("Photo Gallery") { print("Photo Gallery") }
+				Button("Camera") { showCamera.toggle()}
+				Button("Photo Gallery") { showGallery.toggle()}
 				Button("Cancel", role: .cancel) { }
 			} message: {
 				Text("Please take a new photo or select an image from the image gallery")
+			}
+		}
+		.photosPicker(
+			isPresented: $showGallery,
+			selection: $selectedItem,
+			matching: .any(of: [.images, .screenshots, .livePhotos])
+		)
+		.fullScreenCover(
+			isPresented: $showCamera,
+			content: {
+				CameraView(selectedImage: self.$selectedImage)
+					.edgesIgnoringSafeArea(.all)
+			}
+		)
+		.onChange(of: selectedImage) {
+			//TODO: remove imageToDisplay. For testing purposes only.
+			if let image = selectedImage {
+				imageToDisplay = Image(uiImage: image)
+			}
+		}
+		.onChange(of: selectedItem) {
+			Task {
+				if let item = selectedItem {
+					if let data = try? await item.loadTransferable(type: Data.self) {
+						selectedImage = UIImage(data: data)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In this PR I added:

- `Camera` access through `CameraView`.
- `Photo Gallery` access through `PhotosPicker`.
- An `imageToDisplay` that is viewable once an `Image` is selected, either through `CameraView` or `PhotosPicker`. (For testing purposes only. `TODO` added in file to note that this functionality will be removed.)

Image Flow Screenshot(iPhone 15 Pro):
<img src="https://github.com/SLRAM/FairShare/assets/28938900/b4281076-8bab-4fd6-b0fe-f018f53cfb29" width="184" height="400">

Next Goal:

- Once a photo is available process the text in image.
- Take processed text and display it.