### PR TITLE
[ReceiptView] Add Image Processing

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		909E699C2C02C820009D00D6 /* Image+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699B2C02C820009D00D6 /* Image+Helper.swift */; };
 		909E699E2C02C82A009D00D6 /* Color+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699D2C02C82A009D00D6 /* Color+Helper.swift */; };
 		909E69A02C02C865009D00D6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699F2C02C865009D00D6 /* Constants.swift */; };
+		90BD783A2C0AEEB300C6A889 /* ReceiptItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */; };
+		90BD783C2C0C051E00C6A889 /* EditableReceiptItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */; };
 		90F5749F2BF93BCC005A9A2E /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F5749E2BF93BCC005A9A2E /* MainTabView.swift */; };
 		90FB96152BF020490061E83D /* ReceiptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FB96142BF020490061E83D /* ReceiptModel.swift */; };
 		90FB96172BF023340061E83D /* Date+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FB96162BF023340061E83D /* Date+Helper.swift */; };
@@ -94,6 +96,8 @@
 		909E699B2C02C820009D00D6 /* Image+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Helper.swift"; sourceTree = "<group>"; };
 		909E699D2C02C82A009D00D6 /* Color+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Helper.swift"; sourceTree = "<group>"; };
 		909E699F2C02C865009D00D6 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptItemsView.swift; sourceTree = "<group>"; };
+		90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableReceiptItemView.swift; sourceTree = "<group>"; };
 		90F5749E2BF93BCC005A9A2E /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		90FB96142BF020490061E83D /* ReceiptModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptModel.swift; sourceTree = "<group>"; };
 		90FB96162BF023340061E83D /* Date+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Helper.swift"; sourceTree = "<group>"; };
@@ -225,8 +229,10 @@
 			isa = PBXGroup;
 			children = (
 				902C01F92BF017660004B01A /* ReceiptView.swift */,
-				909E69932C02A5C7009D00D6 /* CameraView.swift */,
 				90FB96182BF029190061E83D /* NewReceiptView.swift */,
+				909E69932C02A5C7009D00D6 /* CameraView.swift */,
+				90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */,
+				90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */,
 			);
 			path = Receipt;
 			sourceTree = "<group>";
@@ -481,7 +487,9 @@
 				90FB96312BF08C240061E83D /* FirebaseErrors.swift in Sources */,
 				90FB96192BF029190061E83D /* NewReceiptView.swift in Sources */,
 				909E699E2C02C82A009D00D6 /* Color+Helper.swift in Sources */,
+				90BD783A2C0AEEB300C6A889 /* ReceiptItemsView.swift in Sources */,
 				90FB962D2BF0753E0061E83D /* ProfileView.swift in Sources */,
+				90BD783C2C0C051E00C6A889 /* EditableReceiptItemView.swift in Sources */,
 				9072AFC72BE9C46E00DE6FEB /* EntryView.swift in Sources */,
 				90FB96172BF023340061E83D /* Date+Helper.swift in Sources */,
 				909E69942C02A5C7009D00D6 /* CameraView.swift in Sources */,

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -31,10 +31,10 @@ internal final class TextAsset {
 
 }
 
-enum ConstantColors {
+enum Colors {
 }
 
-enum ConstantImages {
+enum Images {
 	enum System {
 		static let arrowLeftCircleFill = ImageAsset(name: "arrow.left.circle.fill", isSystem: true)
 		static let arrowRight = ImageAsset(name: "arrow.right", isSystem: true)
@@ -45,7 +45,7 @@ enum ConstantImages {
 	}
 }
 
-enum ConstantStrings {
+enum Strings {
 	enum LoginView {
 		static let confirmString = "OK"
 		static let welcome = "Welcome Back"
@@ -72,7 +72,15 @@ enum ConstantStrings {
 	}
 
 	enum ReceiptView {
-		static let navigationTitle = "Receipt History"
+		static let navigationTitle = TextAsset(string: "Receipt History")
+		static let emptyState = TextAsset(string: "Click the + to add a new receipt")
+	}
+
+	enum NewReceiptView {
+		static let navigationTitle = TextAsset(string: "New Receipt")
+		static let editButton = TextAsset(string: "Edit")
+		static let saveButton = TextAsset(string: "Save")
+
 		static let cameraButton = "Camera"
 		static let galleryButton = "Photo Gallery"
 		static let cancelButton = "Cancel"

--- a/FairShare/Models/ReceiptModel.swift
+++ b/FairShare/Models/ReceiptModel.swift
@@ -15,3 +15,54 @@ struct ReceiptModel: Identifiable {
 	var tip: Double
 	var total: Double
 }
+
+protocol ReceiptText: Identifiable, Comparable {
+	var id: UUID { get }
+	var title: String { get set }
+
+}
+
+class ReceiptItem: ReceiptText {
+	let id: UUID
+	var title: String
+	var cost: Double
+
+	init(id: UUID = UUID(), title: String, cost: Double) {
+		self.id = id
+		self.title = title
+		self.cost = cost
+	}
+
+	var costAsCurrency: String {
+		return String(format: "$%.02f", self.cost)
+
+	}
+
+	static func == (lhs: ReceiptItem, rhs: ReceiptItem) -> Bool {
+		return lhs.id == rhs.id && lhs.title == rhs.title && lhs.cost == rhs.cost
+	}
+
+
+	static func < (lhs: ReceiptItem, rhs: ReceiptItem) -> Bool {
+		return lhs.id < rhs.id
+	}
+}
+
+class ReceiptInformation: ReceiptText {
+	let id: UUID
+	var title: String
+
+	init(id: UUID = UUID(), title: String) {
+		self.id = id
+		self.title = title
+	}
+
+	static func == (lhs: ReceiptInformation, rhs: ReceiptInformation) -> Bool {
+		return lhs.id == rhs.id && lhs.title == rhs.title
+	}
+
+	static func < (lhs: ReceiptInformation, rhs: ReceiptInformation) -> Bool {
+		return lhs.id < rhs.id
+	}
+
+}

--- a/FairShare/UI/Authentication/InputView.swift
+++ b/FairShare/UI/Authentication/InputView.swift
@@ -44,11 +44,11 @@ enum InputType: CustomStringConvertible {
 	var placeholder: String {
 		switch self {
 		case .email:
-			return ConstantStrings.LoginView.emailPlaceholder
+			return Strings.LoginView.emailPlaceholder
 		case .password:
-			return ConstantStrings.LoginView.passwordPlaceholder
+			return Strings.LoginView.passwordPlaceholder
 		case .firstName, .lastName:
-			return ConstantStrings.LoginView.namePlaceholder + self.description.lowercased()
+			return Strings.LoginView.namePlaceholder + self.description.lowercased()
 		case .confirmPassword:
 			return self.description
 		}
@@ -57,15 +57,15 @@ enum InputType: CustomStringConvertible {
 	var description: String {
 		switch self {
 		case .firstName:
-			return ConstantStrings.LoginView.firstName
+			return Strings.LoginView.firstName
 		case .lastName:
-			return ConstantStrings.LoginView.LastName
+			return Strings.LoginView.LastName
 		case .email:
-			return ConstantStrings.LoginView.email
+			return Strings.LoginView.email
 		case .password:
-			return ConstantStrings.LoginView.password
+			return Strings.LoginView.password
 		case .confirmPassword:
-			return ConstantStrings.LoginView.confirmPassword
+			return Strings.LoginView.confirmPassword
 		}
 	}
 

--- a/FairShare/UI/Authentication/LoginView.swift
+++ b/FairShare/UI/Authentication/LoginView.swift
@@ -78,7 +78,7 @@ struct LoginView: View {
 						HStack {
 							Text(viewType.buttonTitleString.uppercased())
 								.fontWeight(.semibold)
-							ConstantImages.System.arrowRight.image
+							Images.System.arrowRight.image
 
 						}
 						.foregroundStyle(.white)
@@ -118,7 +118,7 @@ struct LoginView: View {
 			}
 		}
 		.alert(viewModel.errorMessage, isPresented: $viewModel.showAlert) {
-			Button(ConstantStrings.LoginView.confirmString, role: .cancel) { viewModel.showAlert = false }
+			Button(Strings.LoginView.confirmString, role: .cancel) { viewModel.showAlert = false }
 				}
 	}
 }
@@ -131,36 +131,36 @@ extension LoginView {
 		var titleString: String {
 			switch self {
 			case .login:
-				ConstantStrings.LoginView.welcome
+				Strings.LoginView.welcome
 			case .register:
-				ConstantStrings.LoginView.register
+				Strings.LoginView.register
 			}
 		}
 
 		var buttonTitleString: String {
 			switch self {
 			case .login:
-				return ConstantStrings.LoginView.signIn
+				return Strings.LoginView.signIn
 			case .register:
-				return ConstantStrings.LoginView.signUp
+				return Strings.LoginView.signUp
 			}
 		}
 
 		var buttonSwitchString: String {
 			switch self {
 			case .login:
-				return ConstantStrings.LoginView.doesNotHaveAccount
+				return Strings.LoginView.doesNotHaveAccount
 			case .register:
-				return ConstantStrings.LoginView.hasAccount
+				return Strings.LoginView.hasAccount
 			}
 		}
 
 		var buttonSwitchSubString: String {
 			switch self {
 			case .login:
-				return ConstantStrings.LoginView.signUp
+				return Strings.LoginView.signUp
 			case .register:
-				return ConstantStrings.LoginView.signIn
+				return Strings.LoginView.signIn
 			}
 		}
 	}

--- a/FairShare/UI/Main/MainTabView.swift
+++ b/FairShare/UI/Main/MainTabView.swift
@@ -15,15 +15,15 @@ struct MainTabView: View {
 			ReceiptView()
 				.tabItem {
 					Label(
-						title: { ConstantStrings.MainTabView.receiptsTab.text },
-						icon: { ConstantImages.System.listDash.image }
+						title: { Strings.MainTabView.receiptsTab.text },
+						icon: { Images.System.listDash.image }
 					)
 				}
 			ProfileView()
 				.tabItem {
 					Label(
-						title: { ConstantStrings.MainTabView.profileTab.text },
-						icon: { ConstantImages.System.personCropCircle.image }
+						title: { Strings.MainTabView.profileTab.text },
+						icon: { Images.System.personCropCircle.image }
 					)
 				}
 		}

--- a/FairShare/UI/Profile/ProfileView.swift
+++ b/FairShare/UI/Profile/ProfileView.swift
@@ -35,7 +35,7 @@ struct ProfileView: View {
 					}
 				}
 
-				Section(ConstantStrings.ProfileView.account) {
+				Section(Strings.ProfileView.account) {
 					Button {
 						viewModel.signOut()
 					} label: {
@@ -43,7 +43,7 @@ struct ProfileView: View {
 					}
 
 					Button {
-						print(ConstantStrings.ProfileView.delete)
+						print(Strings.ProfileView.delete)
 					} label: {
 						SettingsRowView(rowType: .delete)
 					}

--- a/FairShare/UI/Profile/SettingsRowView.swift
+++ b/FairShare/UI/Profile/SettingsRowView.swift
@@ -15,18 +15,18 @@ struct SettingsRowView: View {
 		var image: Image {
 			switch self {
 			case .signOut:
-				return ConstantImages.System.arrowLeftCircleFill.image
+				return Images.System.arrowLeftCircleFill.image
 			case .delete:
-				return ConstantImages.System.xMarkCircleFill.image
+				return Images.System.xMarkCircleFill.image
 			}
 		}
 
 		var title: String {
 			switch self {
 			case .signOut:
-				return ConstantStrings.ProfileView.signOut
+				return Strings.ProfileView.signOut
 			case .delete:
-				return ConstantStrings.ProfileView.delete
+				return Strings.ProfileView.delete
 			}
 		}
 

--- a/FairShare/UI/Receipt/CameraView.swift
+++ b/FairShare/UI/Receipt/CameraView.swift
@@ -7,38 +7,215 @@
 
 import PhotosUI
 import SwiftUI
+import VisionKit
+import Vision
 
 struct CameraView: UIViewControllerRepresentable {
+	@Environment(\.presentationMode) var presentationMode
+
+	@Binding var recognizedTexts: [any ReceiptText]
+	//TODO: remove visualizedImage. For testing purposes only.
+	@Binding var visualizedImage: UIImage?
 	@Binding var selectedImage: UIImage?
-	@Environment(\.presentationMode) var isPresented
-
-	func makeUIViewController(context: Context) -> UIImagePickerController {
-		let imagePicker = UIImagePickerController()
-		imagePicker.sourceType = .camera
-		imagePicker.allowsEditing = true
-		imagePicker.delegate = context.coordinator
-		return imagePicker
-	}
-
-	func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
-
-	}
 
 	func makeCoordinator() -> Coordinator {
-		return Coordinator(picker: self)
+		Coordinator(visualizedImage: $visualizedImage, selectedImage: $selectedImage,recognizedTexts: $recognizedTexts, parent: self)
+	}
+
+	func makeUIViewController(context: Context) -> VNDocumentCameraViewController {
+		let documentViewController = VNDocumentCameraViewController()
+		documentViewController.delegate = context.coordinator
+		return documentViewController
+	}
+
+	func updateUIViewController(_ uiViewController: VNDocumentCameraViewController, context: Context) {
+	}
+
+	class Coordinator: NSObject, VNDocumentCameraViewControllerDelegate {
+		var recognizedTexts: Binding<[any ReceiptText]>
+		var visualizedImage: Binding<UIImage?>
+		var selectedImage: Binding<UIImage?>
+
+		var parent: CameraView
+
+		init(visualizedImage: Binding<UIImage?>, selectedImage: Binding<UIImage?>, recognizedTexts: Binding<[any ReceiptText]>, parent: CameraView) {
+			self.visualizedImage = visualizedImage
+			self.recognizedTexts = recognizedTexts
+			self.selectedImage = selectedImage
+			self.parent = parent
+		}
+
+		func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
+			let extractedImage = Processor.extractImage(from: scan)
+
+			let processedImage = Processor.visualizeImage(from: extractedImage)
+			let processedText = Processor.recognizeText(from: extractedImage)
+
+			visualizedImage.wrappedValue = processedImage
+			selectedImage.wrappedValue = extractedImage
+			recognizedTexts.wrappedValue = processedText
+
+			parent.presentationMode.wrappedValue.dismiss()
+		}
 	}
 }
 
-class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
-	var picker: CameraView
+enum Processor {
+	static func extractImage(from scan: VNDocumentCameraScan) -> UIImage {
+		let extractedImage = scan.imageOfPage(at: 0)
 
-	init(picker: CameraView) {
-		self.picker = picker
+		return extractedImage
 	}
 
-	func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-		guard let selectedImage = info[.originalImage] as? UIImage else { return }
-		self.picker.selectedImage = selectedImage
-		self.picker.isPresented.wrappedValue.dismiss()
+	static func extractImage(from item: PhotosPickerItem?) async -> UIImage {
+		var extractedImage: UIImage = UIImage()
+
+			if let item = item {
+				var image: UIImage?
+				if let data = try? await item.loadTransferable(type: Data.self) {
+					image = UIImage(data: data)
+				}
+
+				if let image = image {
+					extractedImage = image
+			}
+		}
+
+		return extractedImage
+
+	}
+
+	static func visualizeImage(from image: UIImage) -> UIImage {
+		var visualizedImage = UIImage()
+
+		let recognizeTextRequest = VNRecognizeTextRequest { request, error in
+			guard let observations = request.results as? [VNRecognizedTextObservation] else {
+				print("Error: \(error! as NSError)")
+				return
+			}
+
+			visualizedImage = self.visualization(image, observations: observations)
+		}
+
+		recognizeTextRequest.recognitionLevel = .accurate
+
+		if let cgImage = image.cgImage {
+			let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+
+			try? requestHandler.perform([recognizeTextRequest])
+		}
+
+		return visualizedImage
+	}
+
+	static func visualization(_ image: UIImage, observations: [VNDetectedObjectObservation]) -> UIImage {
+		var transform = CGAffineTransform.identity
+			.scaledBy(x: 1, y: -1)
+			.translatedBy(x: 1, y: -image.size.height)
+
+		transform = transform.scaledBy(x: image.size.width, y: image.size.height)
+
+		UIGraphicsBeginImageContextWithOptions(image.size, true, 0.0)
+		let context = UIGraphicsGetCurrentContext()
+
+		image.draw(in: CGRect(origin: .zero, size: image.size))
+		context?.saveGState()
+
+		context?.setLineWidth(2)
+		context?.setLineJoin(CGLineJoin.round)
+		context?.setStrokeColor(UIColor.black.cgColor)
+		context?.setFillColor(red: 0, green: 1, blue: 0, alpha: 0.3)
+
+		observations.forEach { observation in
+			let bounds = observation.boundingBox.applying(transform)
+			context?.addRect(bounds)
+		}
+
+		context?.drawPath(using: CGPathDrawingMode.fillStroke)
+		context?.restoreGState()
+
+		let resultImage = UIGraphicsGetImageFromCurrentImageContext()
+		UIGraphicsEndImageContext()
+
+		return resultImage!
+	}
+
+	static func recognizeText(from image: UIImage) -> [any ReceiptText] {
+		var entireRecognizedTexts: [any ReceiptText] = []
+
+		let recognizeTextRequest = VNRecognizeTextRequest { (request, error) in
+			guard error == nil else { return }
+			guard let observations = request.results as? [VNRecognizedTextObservation] else { return }
+
+			entireRecognizedTexts = self.makeReceiptText(from: observations)
+		}
+
+		recognizeTextRequest.recognitionLevel = .accurate
+
+		if let cgImage = image.cgImage {
+			let requestHandler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+
+			try? requestHandler.perform([recognizeTextRequest])
+		}
+
+		return entireRecognizedTexts
+	}
+
+	static func sortObservations(from observations: [VNRecognizedTextObservation]) -> [VNRecognizedTextObservation] {
+		let yRange: CGFloat = 0.02
+		return observations.sorted {
+			let midYFirst = $0.boundingBox.midY
+			let midYSecond = $1.boundingBox.midY
+
+			if abs(midYFirst - midYSecond) > yRange {
+				return midYFirst > midYSecond
+			} else {
+				return $0.boundingBox.minX < $1.boundingBox.minX
+			}
+		}
+	}
+
+	static func makeReceiptText(from observations: [VNRecognizedTextObservation]) -> [any ReceiptText] {
+		let yRange: CGFloat = 0.02
+
+		var receiptText: [any ReceiptText] = []
+
+		let sortedObservations = sortObservations(from: observations)
+		let maximumRecognitionCandidates = 1
+
+		var index = 0
+		while index < sortedObservations.count - 1 {
+			let current = sortedObservations[index]
+			let next = sortedObservations[index + 1]
+
+			guard let candidateOne = current.topCandidates(maximumRecognitionCandidates).first else {
+				index += 1
+				continue
+			}
+			guard let candidateTwo = next.topCandidates(maximumRecognitionCandidates).first else {
+				index += 1
+				continue
+			}
+
+			let midYCurrent = current.boundingBox.midY
+			let midYNext = next.boundingBox.midY
+
+			if abs(midYCurrent - midYNext) <= yRange {
+				let key = current.boundingBox.minX < next.boundingBox.minX ? candidateOne.string : candidateTwo.string
+				let valueString = current.boundingBox.minX < next.boundingBox.minX ? candidateTwo.string : candidateOne.string
+
+				if let value = Double(valueString) {
+					receiptText.append(ReceiptItem(title: key, cost: value))
+				}
+				index += 2
+			} else {
+				let title = candidateOne.string
+				receiptText.append(ReceiptInformation(title: title))
+
+				index += 1
+			}
+		}
+
+		return receiptText
 	}
 }

--- a/FairShare/UI/Receipt/EditableReceiptItemView.swift
+++ b/FairShare/UI/Receipt/EditableReceiptItemView.swift
@@ -1,0 +1,40 @@
+//
+//  EditableReceiptItemView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/1/24.
+//
+
+import SwiftUI
+
+struct EditableReceiptItemView: View {
+	@Binding var item: ReceiptItem
+	@State private var editedItem: String = ""
+	@State private var editedCost: String = ""
+
+	var body: some View {
+		HStack {
+			TextField("Enter item", text: $editedItem, onCommit: {
+				item.title = editedItem
+			})
+			.textFieldStyle(RoundedBorderTextFieldStyle())
+
+			TextField("Enter cost", text: $editedCost, onCommit: {
+				if let newCost = Double(editedCost) {
+					item.cost = newCost
+				}
+			})
+			.textFieldStyle(RoundedBorderTextFieldStyle())
+			.keyboardType(.decimalPad)
+			.multilineTextAlignment(.trailing)
+			.onAppear {
+				editedItem = item.title
+				editedCost = String(format: "%.2f", item.cost)
+			}
+		}
+	}
+}
+
+#Preview {
+	EditableReceiptItemView(item: .constant(ReceiptItem(title: "Apple", cost: 1.99)))
+}

--- a/FairShare/UI/Receipt/NewReceiptView.swift
+++ b/FairShare/UI/Receipt/NewReceiptView.swift
@@ -5,16 +5,101 @@
 //  Created by Stephanie Ramirez on 5/11/24.
 //
 
+import Firebase
+import PhotosUI
 import SwiftUI
 
 struct NewReceiptView: View {
-	//add a button for photo capture
-	//add a button for opening library
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
+	@Environment(\.dismiss) var dismiss
+	@EnvironmentObject var authViewModel: AuthViewModel
+
+	@State private var showActionSheet = true
+	@State private var showCamera = false
+	@State private var showGallery = false
+	@State private var selectedImage: UIImage?
+	@State private var selectedItem: PhotosPickerItem?
+//	@State private var receiptItems: [ReceiptItem] = []
+	@State private var receiptTexts: [any ReceiptText] = []
+
+	@State private var isEditing = false
+	@State private var showReceiptTab: Bool = false
+
+	//TODO: remove imageToDisplay and visualizedImage. For testing purposes only.
+	@State private var imageToDisplay: Image?
+	@State private var visualizedImage: UIImage?
+
+	var body: some View {
+		NavigationStack {
+			//TODO: remove imageToDisplay. For testing purposes only.
+//			if let currentImage = imageToDisplay {
+//				currentImage
+//					.resizable()
+//					.scaledToFit()
+//					.frame(width: 300, height: 300)
+//				ShareLink(item: currentImage, preview: SharePreview("Current Image", image: currentImage))
+//			}
+			
+			ReceiptItemsView(receiptTexts: $receiptTexts, isEditing: $isEditing)
+				.navigationBarTitleDisplayMode(.automatic)
+				.toolbar {
+					ToolbarItem(placement: .principal) {
+						Strings.NewReceiptView.navigationTitle.text.font(.headline)
+					}
+					if !receiptTexts.isEmpty {
+						ToolbarItem(placement: .topBarTrailing) {
+							Button {
+								isEditing.toggle()
+							} label: {
+								Strings.NewReceiptView.editButton.text
+							}
+						}
+					}
+				}
+			
+			if !receiptTexts.isEmpty {
+				Button {
+					dismiss()
+				} label: {
+					Strings.NewReceiptView.saveButton.text
+				}
+			}
+		}
+		.confirmationDialog("", isPresented: $showActionSheet) {
+			Button(Strings.NewReceiptView.cameraButton) { showCamera.toggle() }
+			Button(Strings.NewReceiptView.galleryButton) { showGallery.toggle() }
+			Button(Strings.NewReceiptView.cancelButton, role: .cancel) { dismiss() }
+		} message: {
+			Strings.NewReceiptView.confirmationMessage.text
+		}
+		.photosPicker(
+			isPresented: $showGallery,
+			selection: $selectedItem,
+			matching: .any(of: [.images, .screenshots, .livePhotos])
+		)
+		.fullScreenCover(
+			isPresented: $showCamera,
+			content: {
+				CameraView(recognizedTexts: self.$receiptTexts, visualizedImage: self.$visualizedImage, selectedImage: self.$selectedImage)
+					.edgesIgnoringSafeArea(.all)
+			}
+		)
+		.onChange(of: selectedImage) {
+			//TODO: remove imageToDisplay. For testing purposes only.
+			///selectedImage will be saved for the final uploaded receipt.
+			if let image = selectedImage {
+				imageToDisplay = Image(uiImage: image)
+			}
+		}
+		.onChange(of: selectedItem) {
+			Task {
+				let image = await Processor.extractImage(from: selectedItem)
+				selectedImage = image
+				receiptTexts = Processor.recognizeText(from: image)
+			}
+		}
+	}
 }
 
 #Preview {
-    NewReceiptView()
+	NewReceiptView().environmentObject(AuthViewModel())
 }

--- a/FairShare/UI/Receipt/ReceiptItemsView.swift
+++ b/FairShare/UI/Receipt/ReceiptItemsView.swift
@@ -1,0 +1,48 @@
+//
+//  ReceiptItemsView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/1/24.
+//
+
+import SwiftUI
+
+//TODO rename ReceiptTextView
+struct ReceiptItemsView: View {
+	@Binding var receiptTexts: [any ReceiptText]
+	@Binding var isEditing: Bool
+
+	var receiptItems: [ReceiptItem] {
+		receiptTexts.compactMap { $0 as? ReceiptItem }
+	}
+
+	var body: some View {
+		List {
+			ForEach(receiptItems, id: \.id) { receiptItem in
+				if let index = receiptTexts.firstIndex(where: { $0.id == receiptItem.id }) {
+					if isEditing {
+						EditableReceiptItemView(item: Binding(
+							get: { receiptTexts[index] as! ReceiptItem },
+							set: { receiptTexts[index] = $0 }
+						))
+					} else {
+						HStack {
+							Text(receiptItem.title)
+							Spacer()
+							Text(receiptItem.costAsCurrency)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+#Preview {
+	ReceiptItemsView(receiptTexts: .constant([
+		ReceiptInformation(title: "Fruit Shop"),
+		ReceiptItem(title: "Apple", cost: 1.99),
+		ReceiptItem(title: "Banana", cost: 0.99),
+		ReceiptItem(title: "Orange", cost: 1.49)
+	]), isEditing: .constant(false))
+}

--- a/FairShare/UI/Receipt/ReceiptView.swift
+++ b/FairShare/UI/Receipt/ReceiptView.swift
@@ -11,68 +11,40 @@ import SwiftUI
 
 struct ReceiptView: View {
 	@EnvironmentObject var authViewModel: AuthViewModel
-	@State private var showActionSheet = false
-	@State private var showCamera = false
-	@State private var showGallery = false
-	@State private var selectedImage: UIImage?
-	@State private var selectedItem: PhotosPickerItem?
-	@State private var imageToDisplay: Image?
+	
+	@State private var selectedReceipt: ReceiptModel? = nil
+	@State private var isPresented = false
 
 	var body: some View {
 		NavigationStack {
-			//TODO: remove imageToDisplay. For testing purposes only.
-			imageToDisplay?
-				.resizable()
-				.scaledToFit()
-				.frame(width: 300, height: 300)
-
 			List(authViewModel.receipts, id: \.id) { receipt in
 				Text(receipt.date)
+					.onTapGesture {
+						selectedReceipt = receipt
+					}
 			}
-			.navigationTitle(ConstantStrings.ReceiptView.navigationTitle)
+			.overlay(
+				Group {
+					if authViewModel.receipts.isEmpty {
+						Strings.ReceiptView.emptyState.text
+					}
+				}
+			)
 			.toolbar {
+				ToolbarItem(placement: .principal) {
+					Strings.ReceiptView.navigationTitle.text.font(.headline)
+				}
 				ToolbarItem(placement: .topBarTrailing) {
 					Button {
-						showActionSheet.toggle()
+						isPresented.toggle()
 					} label: {
-						ConstantImages.System.plus.image
+						Images.System.plus.image
 					}
 				}
 			}
-			.confirmationDialog("", isPresented: $showActionSheet) {
-				Button(ConstantStrings.ReceiptView.cameraButton) { showCamera.toggle()}
-				Button(ConstantStrings.ReceiptView.galleryButton) { showGallery.toggle()}
-				Button(ConstantStrings.ReceiptView.cancelButton, role: .cancel) { }
-			} message: {
-				ConstantStrings.ReceiptView.confirmationMessage.text
-			}
 		}
-		.photosPicker(
-			isPresented: $showGallery,
-			selection: $selectedItem,
-			matching: .any(of: [.images, .screenshots, .livePhotos])
-		)
-		.fullScreenCover(
-			isPresented: $showCamera,
-			content: {
-				CameraView(selectedImage: self.$selectedImage)
-					.edgesIgnoringSafeArea(.all)
-			}
-		)
-		.onChange(of: selectedImage) {
-			//TODO: remove imageToDisplay. For testing purposes only.
-			if let image = selectedImage {
-				imageToDisplay = Image(uiImage: image)
-			}
-		}
-		.onChange(of: selectedItem) {
-			Task {
-				if let item = selectedItem {
-					if let data = try? await item.loadTransferable(type: Data.self) {
-						selectedImage = UIImage(data: data)
-					}
-				}
-			}
+		.fullScreenCover(isPresented: $isPresented) {
+			NewReceiptView()
 		}
 	}
 }


### PR DESCRIPTION
In this PR I added:
- `VisionKit` to `CameraView` and `Processor`.
- A list to display `ReceiptItems` that are processed from either the `CameraView` or `PhotosPicker`.
- Edit functionality so the user can change any `ReceiptItem` that is incorrect.

Image Flow Screenshot(iPhone 15 Pro):
<img src="https://github.com/SLRAM/FairShare/assets/28938900/5dd6916d-c3fc-431f-b143-9b8189629a31" width="184" height="400">

Image Being Processed in `PhotosPicker`:
<img src="https://github.com/SLRAM/FairShare/assets/28938900/13bd1f9c-9750-467c-95c5-bafcb8999786" width="184" height="400">

Next Goal:
- Upload `ReceiptModel` data when user taps the Save button.
- Display `ReceiptModel` data for user that was fetched from Firebase.
- Dismiss `NewReceiptView` if user cancels `CameraView` or `PhotosPicker`.