### PR TITLE
[Upload Image] Allow user to upload images to storage

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		909E69A02C02C865009D00D6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699F2C02C865009D00D6 /* Constants.swift */; };
 		90BD783A2C0AEEB300C6A889 /* ReceiptItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */; };
 		90BD783C2C0C051E00C6A889 /* EditableReceiptItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */; };
+		90F329842C1DB90D003AA887 /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F329832C1DB90D003AA887 /* StorageService.swift */; };
 		90F4761D2C14F6510075B36B /* DBService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F4761C2C14F6510075B36B /* DBService.swift */; };
 		90F4761F2C154FE20075B36B /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F4761E2C154FE20075B36B /* AuthService.swift */; };
 		90F476212C1581950075B36B /* ReceiptCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F476202C1581950075B36B /* ReceiptCardView.swift */; };
@@ -101,6 +102,7 @@
 		909E699F2C02C865009D00D6 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptItemsView.swift; sourceTree = "<group>"; };
 		90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableReceiptItemView.swift; sourceTree = "<group>"; };
+		90F329832C1DB90D003AA887 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		90F4761C2C14F6510075B36B /* DBService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBService.swift; sourceTree = "<group>"; };
 		90F4761E2C154FE20075B36B /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		90F476202C1581950075B36B /* ReceiptCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptCardView.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 			children = (
 				90F4761E2C154FE20075B36B /* AuthService.swift */,
 				90F4761C2C14F6510075B36B /* DBService.swift */,
+				90F329832C1DB90D003AA887 /* StorageService.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 				90F5749F2BF93BCC005A9A2E /* MainTabView.swift in Sources */,
 				90FB96152BF020490061E83D /* ReceiptModel.swift in Sources */,
 				90FB962F2BF0779B0061E83D /* SettingsRowView.swift in Sources */,
+				90F329842C1DB90D003AA887 /* StorageService.swift in Sources */,
 				902C01FC2BF019770004B01A /* AuthViewModel.swift in Sources */,
 				909E699C2C02C820009D00D6 /* Image+Helper.swift in Sources */,
 				90FB96312BF08C240061E83D /* FirebaseErrors.swift in Sources */,

--- a/FairShare/Errors/FirebaseErrors.swift
+++ b/FairShare/Errors/FirebaseErrors.swift
@@ -8,25 +8,64 @@
 import Foundation
 import Firebase
 
-extension AuthErrorCode {
-	var errorMessage: String {
-		switch self.code {
+protocol DBError: Error {}
+
+enum FirebaseAuthError: DBError {
+	case emailAlreadyInUse
+	case userNotFound
+	case userDisabled
+	case invalidEmail
+	case networkError
+	case weakPassword
+	case wrongPassword
+	case operationNotAllowed
+	case unknownError(String)
+
+	init(_ error: NSError) {
+		let authErrorCode = AuthErrorCode(_nsError: error).code
+
+		switch authErrorCode {
 		case .emailAlreadyInUse:
-			return "This email is already in use with another account"
+			self = .emailAlreadyInUse
 		case .userNotFound:
-			return "Account not found for the specified user. Please check and try again"
+			self = .userNotFound
+		case .userDisabled:
+			self = .userDisabled
+		case .invalidEmail, .invalidSender, .invalidRecipientEmail:
+			self = .invalidEmail
+		case .networkError:
+			self = .networkError
+		case .weakPassword:
+			self = .weakPassword
+		case .wrongPassword:
+			self = .wrongPassword
+		case .operationNotAllowed:
+			self = .operationNotAllowed
+		default:
+			self = .unknownError("\(authErrorCode)")
+		}
+	}
+
+	var errorMessage: String {
+		switch self {
+		case .emailAlreadyInUse:
+			return "This email is already in use with another account."
+		case .userNotFound:
+			return "Account not found for the specified user. Please check and try again."
 		case .userDisabled:
 			return "Your account has been disabled. Please contact support."
-		case .invalidEmail, .invalidSender, .invalidRecipientEmail:
-			return "Please enter a valid email"
+		case .invalidEmail:
+			return "Please enter a valid email."
 		case .networkError:
 			return "Network error. Please try again."
 		case .weakPassword:
 			return "Your password is too weak. The password must be 6 characters long or more."
 		case .wrongPassword:
 			return "Your password is incorrect. Please try again."
-		default:
-			return "Unknown error occurred. Error code: \(self.errorCode)"
+		case .operationNotAllowed:
+			return "Sign in with this method is currently disabled. Please contact support for further assistance."
+		case .unknownError(let code):
+			return "Unknown error occurred. Error code: \(code)"
 		}
 	}
 }

--- a/FairShare/Errors/FirebaseErrors.swift
+++ b/FairShare/Errors/FirebaseErrors.swift
@@ -19,6 +19,7 @@ enum FirebaseAuthError: DBError {
 	case weakPassword
 	case wrongPassword
 	case operationNotAllowed
+	case keychainError
 	case unknownError(String)
 
 	init(_ error: NSError) {
@@ -41,6 +42,8 @@ enum FirebaseAuthError: DBError {
 			self = .wrongPassword
 		case .operationNotAllowed:
 			self = .operationNotAllowed
+		case .keychainError:
+			self = .keychainError
 		default:
 			self = .unknownError("\(authErrorCode)")
 		}
@@ -64,6 +67,8 @@ enum FirebaseAuthError: DBError {
 			return "Your password is incorrect. Please try again."
 		case .operationNotAllowed:
 			return "Sign in with this method is currently disabled. Please contact support for further assistance."
+		case .keychainError:
+			return "An error occurred while trying to access secure information. Please try again or contact support if the problem persists."
 		case .unknownError(let code):
 			return "Unknown error occurred. Error code: \(code)"
 		}

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -98,6 +98,7 @@ struct Strings {
 struct Constants {
 	static let ProfileImagePath = "profileImages/"
 	static let ReceiptImagePath = "receiptImages/"
+	static let StorageContentType = "image/jpg"
 
 	struct UserCollectionKeys {
 		static let CollectionKey = "users"
@@ -114,5 +115,9 @@ struct Constants {
 		static let CreatorIDKey = "creatorID"
 		static let DateKey = "date"
 		static let ImageURLKey = "imageURL"
+	}
+
+	struct StorageKeys {
+		static let ImagesKey = "images"
 	}
 }

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -76,6 +76,11 @@ struct Strings {
 		static let emptyState = TextAsset(string: "Click the + to add a new receipt")
 	}
 
+	struct ReceiptCardView {
+		static let dateTitle = TextAsset(string: "Date:")
+		static let creatorTitle = TextAsset(string: "Created by:")
+	}
+
 	struct NewReceiptView {
 		static let navigationTitle = TextAsset(string: "New Receipt")
 		static let editButton = TextAsset(string: "Edit")

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -105,9 +105,9 @@ class AuthViewModel: ObservableObject {
 		isLoading = false
 	}
 
-	func createReceipt(from receiptTexts: [any ReceiptText]) async throws {
+	func createReceipt(from receiptTexts: [any ReceiptText], image: UIImage) async throws {
 		do {
-			try await DBService.createReceipt(from: receiptTexts, creatorID: self.currentUser!.id)
+			try await DBService.createReceipt(from: receiptTexts, image: image, creatorID: self.currentUser!.id)
 			try await self.fetchUserReceipts()
 		} catch {
 			print("Error writing document: \(error)")

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -31,10 +31,8 @@ class AuthViewModel: ObservableObject {
 			let result = try await AuthService.signIn(with: email, password: password)
 			self.userSession = result
 			try await self.fetchUser()
-		} catch let error as NSError {
-			print(AuthErrorCode(_nsError: error).errorMessage)
-			errorMessage = AuthErrorCode(_nsError: error).errorMessage
-			showAlert = true
+		} catch let error as FirebaseAuthError {
+			self.showError(for: error.errorMessage)
 		}
 	}
 
@@ -113,5 +111,10 @@ class AuthViewModel: ObservableObject {
 			print("Error writing document: \(error)")
 			throw error
 		}
+	}
+
+	private func showError(for message: String) {
+		errorMessage = message
+		showAlert = true
 	}
 }

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -41,9 +41,8 @@ class AuthViewModel: ObservableObject {
 			try await AuthService.signOut()
 			self.userSession = nil
 			self.currentUser = nil
-		} catch let error {
-			print("Error signing out user: \(error)")
-			throw error
+		} catch let error as FirebaseAuthError {
+			self.showError(for: error.errorMessage)
 		}
 	}
 

--- a/FairShare/Models/ReceiptModel.swift
+++ b/FairShare/Models/ReceiptModel.swift
@@ -11,14 +11,22 @@ struct ReceiptModel: Identifiable, Codable {
 	var id: UUID
 	var creatorID: String
 	var date: Date
-//	var image: String
+	var imageURL: String
 	//TODO: add guest IDs to display receipt for all guests as well
+
+	init(id: UUID, creatorID: String, date: Date, imageURL: String) {
+		self.id = id
+		self.creatorID = creatorID
+		self.date = date
+		self.imageURL = imageURL
+	}
+
+	static let dummyData: ReceiptModel = ReceiptModel(id: UUID(), creatorID: UUID().uuidString, date: Date(), imageURL: "https://picsum.photos/200/300")
 }
 
 protocol ReceiptText: Identifiable, Comparable {
 	var id: UUID { get }
 	var title: String { get set }
-
 }
 
 class ReceiptItem: ReceiptText {

--- a/FairShare/Models/ReceiptModel.swift
+++ b/FairShare/Models/ReceiptModel.swift
@@ -9,19 +9,19 @@ import Foundation
 
 struct ReceiptModel: Identifiable, Codable {
 	var id: UUID
-	var creatorID: String
+	var creator: UserModel
 	var date: Date
 	var imageURL: String
 	//TODO: add guest IDs to display receipt for all guests as well
 
-	init(id: UUID, creatorID: String, date: Date, imageURL: String) {
+	init(id: UUID, creator: UserModel, date: Date, imageURL: String) {
 		self.id = id
-		self.creatorID = creatorID
+		self.creator = creator
 		self.date = date
 		self.imageURL = imageURL
 	}
 
-	static let dummyData: ReceiptModel = ReceiptModel(id: UUID(), creatorID: UUID().uuidString, date: Date(), imageURL: "https://picsum.photos/200/300")
+	static let dummyData: ReceiptModel = ReceiptModel(id: UUID(), creator: UserModel.dummyData, date: Date(), imageURL: "https://picsum.photos/200/300")
 }
 
 protocol ReceiptText: Identifiable, Comparable {

--- a/FairShare/Models/UserModel.swift
+++ b/FairShare/Models/UserModel.swift
@@ -28,6 +28,10 @@ struct UserModel: Identifiable, Codable {
 		return "\(firstName) \(lastName)"
 	}
 
+	var abbreviatedName: String {
+		return "\(firstName) \(lastName.prefix(1))."
+	}
+
 	static let dummyData: UserModel = UserModel(id: UUID().uuidString, firstName: "Jane", lastName: "Smith", email: "janesmith@gmail.com")
 
 }

--- a/FairShare/Models/UserModel.swift
+++ b/FairShare/Models/UserModel.swift
@@ -27,4 +27,7 @@ struct UserModel: Identifiable, Codable {
 	var fullName: String {
 		return "\(firstName) \(lastName)"
 	}
+
+	static let dummyData: UserModel = UserModel(id: UUID().uuidString, firstName: "Jane", lastName: "Smith", email: "janesmith@gmail.com")
+
 }

--- a/FairShare/Networking/AuthService.swift
+++ b/FairShare/Networking/AuthService.swift
@@ -8,7 +8,6 @@
 import Foundation
 import FirebaseAuth
 
-
 final class AuthService {
 	private init() {}
 
@@ -28,8 +27,8 @@ extension AuthService {
 			let result = try await Authentication.signIn(withEmail: email, password: password)
 			return result.user
 		} catch let error as NSError {
-			print(AuthErrorCode(_nsError: error).errorMessage)
-			throw error
+			print("Error signing in user: \(FirebaseAuthError(error).errorMessage)")
+			throw FirebaseAuthError(error)
 		}
 	}
 

--- a/FairShare/Networking/AuthService.swift
+++ b/FairShare/Networking/AuthService.swift
@@ -35,9 +35,9 @@ extension AuthService {
 	static func signOut() async throws {
 		do {
 			try Authentication.signOut()
-		} catch let error {
-			print("Error signing out user: \(error)")
-			throw error
+		} catch let error as NSError {
+			print("Error signing out user: \(FirebaseAuthError(error).errorMessage)")
+			throw FirebaseAuthError(error)
 		}
 	}
 

--- a/FairShare/Networking/DBService.swift
+++ b/FairShare/Networking/DBService.swift
@@ -135,7 +135,10 @@ extension DBService {
 						continue
 					}
 
-					let receiptModel = ReceiptModel(id: id, creatorID: creatorID, date: date, imageURL: imageUrlString)
+					let creatorSnapshot = try await firestoreDB.collection(Constants.UserCollectionKeys.CollectionKey).document(creatorID).getDocument()
+					let creator = try creatorSnapshot.data(as: UserModel.self)
+
+					let receiptModel = ReceiptModel(id: id, creator: creator, date: date, imageURL: imageUrlString)
 
 					receipts.append(receiptModel)
 				}

--- a/FairShare/Networking/DBService.swift
+++ b/FairShare/Networking/DBService.swift
@@ -65,7 +65,8 @@ extension DBService {
 
 		do {
 			guard let imageData = image.jpegData(compressionQuality: 1.0) else {
-				throw FirestoreDBError.invalidData
+				print("Error converting image data.")
+				return
 			}
 
 			let imageURL = try await StorageService.postImage(imageData: imageData, imageName: Constants.ReceiptImagePath + docID.uuidString)

--- a/FairShare/Networking/DBService.swift
+++ b/FairShare/Networking/DBService.swift
@@ -65,7 +65,7 @@ extension DBService {
 
 		do {
 			guard let imageData = image.jpegData(compressionQuality: 1.0) else {
-				throw ReceiptError.invalidData
+				throw FirestoreDBError.invalidData
 			}
 
 			let imageURL = try await StorageService.postImage(imageData: imageData, imageName: Constants.ReceiptImagePath + docID.uuidString)

--- a/FairShare/Networking/StorageService.swift
+++ b/FairShare/Networking/StorageService.swift
@@ -1,0 +1,28 @@
+//
+//  StorageService.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/15/24.
+//
+
+import Foundation
+import FirebaseStorage
+
+final class StorageService {
+	static var storageRef: StorageReference = {
+		let ref = Storage.storage().reference()
+		return ref
+	}()
+}
+
+extension StorageService {
+	static public func postImage(imageData: Data, imageName: String) async throws -> URL {
+		let metadata = StorageMetadata()
+		metadata.contentType = Constants.StorageContentType
+		let imageRef = storageRef.child(Constants.StorageKeys.ImagesKey + "/\(imageName)")
+
+		let _ = try await imageRef.putDataAsync(imageData, metadata: metadata)
+		return try await imageRef.downloadURL()
+
+	}
+}

--- a/FairShare/UI/Receipt/NewReceiptView.swift
+++ b/FairShare/UI/Receipt/NewReceiptView.swift
@@ -59,7 +59,9 @@ struct NewReceiptView: View {
 			if !receiptTexts.isEmpty {
 				Button {
 					Task {
-						try await authViewModel.createReceipt(from: receiptTexts)
+						if let image = selectedImage {
+							try await authViewModel.createReceipt(from: receiptTexts, image: image)
+						}
 					}
 
 					dismiss()

--- a/FairShare/UI/Receipt/ReceiptCardView.swift
+++ b/FairShare/UI/Receipt/ReceiptCardView.swift
@@ -13,27 +13,26 @@ struct ReceiptCardView: View {
 	var body: some View {
 		VStack(alignment: .leading) {
 			HStack {
-				Text("Date:")
+				Strings.ReceiptCardView.dateTitle.text
 					.font(.headline)
 				Spacer()
 				Text(receipt.date, style: .date)
 					.font(.subheadline)
 			}
+
 			HStack {
-				Text("Created by:")
+				Strings.ReceiptCardView.creatorTitle.text
 					.font(.headline)
 				Spacer()
-				Text(receipt.creatorID)
+				Text(receipt.creator.abbreviatedName)
 					.font(.subheadline)
 					.lineLimit(1)
 			}
 		}
-		.padding()
+		.padding(.all, 10)
 		.background(Color(.systemGray6))
 		.cornerRadius(8)
 		.shadow(radius: 2)
-		.padding(.horizontal)
-		.padding(.vertical, 4)
 	}
 }
 

--- a/FairShare/UI/Receipt/ReceiptCardView.swift
+++ b/FairShare/UI/Receipt/ReceiptCardView.swift
@@ -38,5 +38,5 @@ struct ReceiptCardView: View {
 }
 
 #Preview {
-	ReceiptCardView(receipt: ReceiptModel(id: UUID(), creatorID: UUID().uuidString, date: Date()))
+	ReceiptCardView(receipt: ReceiptModel.dummyData)
 }


### PR DESCRIPTION
In this PR I have added (in order of commits):
- Dedicated file named `StorageService` for `StorageReference` access.
- The ability to upload the `ReceiptModel` image data to `Firestore Database` and `Storage`.
- The ability to view the `abbreviatedName` of a receipt `creator` on the `ReceiptCardView`. The full `UserModel` is stored in the local `ReceiptModel` but only the `creator` ID is stored in the `Receipts` collection.
- Updates to error handling for `signIn` and `signOut` within `AuthService`.

`Created By` update Screenshot(iPhone 15 Pro):

<img src="https://github.com/SLRAM/FairShare/assets/28938900/b314b64e-6137-498a-9b3b-112aab9b0e43" width="184" height="400">


Image `Firestore Database` and `Storage` Screenshot(Firebase):

<img src="https://github.com/SLRAM/FairShare/assets/28938900/b7ddac17-c37a-4fef-8360-ec1afe0cd11f" width="1000" height="500">

Next Goals:
- Account for `TODO` notes in code.
- Finish updating error handling for `DBService`.
- Dismiss `NewReceiptView` if user cancels `CameraView` or `PhotosPicker`.
- Add `ReceiptItems` to Firebase.