### PR TITLE
[ReceiptDetailView] display receipt details

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		902C01FA2BF017660004B01A /* ReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01F92BF017660004B01A /* ReceiptView.swift */; };
 		902C01FC2BF019770004B01A /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01FB2BF019770004B01A /* AuthViewModel.swift */; };
 		902C01FE2BF019B60004B01A /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01FD2BF019B60004B01A /* UserModel.swift */; };
+		902D77022C27766800F7B462 /* ReceiptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902D77012C27766800F7B462 /* ReceiptDetailView.swift */; };
 		902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902D77032C278D9400F7B462 /* CustomToggleStyle.swift */; };
 		9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */; };
 		9072AFC72BE9C46E00DE6FEB /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC62BE9C46E00DE6FEB /* EntryView.swift */; };
@@ -85,6 +86,7 @@
 		902C01F92BF017660004B01A /* ReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptView.swift; sourceTree = "<group>"; };
 		902C01FB2BF019770004B01A /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		902C01FD2BF019B60004B01A /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
+		902D77012C27766800F7B462 /* ReceiptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptDetailView.swift; sourceTree = "<group>"; };
 		902D77032C278D9400F7B462 /* CustomToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggleStyle.swift; sourceTree = "<group>"; };
 		9072AFC12BE9C46E00DE6FEB /* FairShare.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FairShare.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FairShareApp.swift; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				902C01F92BF017660004B01A /* ReceiptView.swift */,
+				902D77012C27766800F7B462 /* ReceiptDetailView.swift */,
 				90F476202C1581950075B36B /* ReceiptCardView.swift */,
 				90FB96182BF029190061E83D /* NewReceiptView.swift */,
 				909E69932C02A5C7009D00D6 /* CameraView.swift */,
@@ -523,6 +526,7 @@
 				909E69A02C02C865009D00D6 /* Constants.swift in Sources */,
 				9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */,
 				902C01FA2BF017660004B01A /* ReceiptView.swift in Sources */,
+				902D77022C27766800F7B462 /* ReceiptDetailView.swift in Sources */,
 				90FB96272BF030B20061E83D /* LoginView.swift in Sources */,
 				9072AFD12BE9C47000DE6FEB /* FairShare.xcdatamodeld in Sources */,
 				90F4761D2C14F6510075B36B /* DBService.swift in Sources */,

--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		902C01FA2BF017660004B01A /* ReceiptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01F92BF017660004B01A /* ReceiptView.swift */; };
 		902C01FC2BF019770004B01A /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01FB2BF019770004B01A /* AuthViewModel.swift */; };
 		902C01FE2BF019B60004B01A /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01FD2BF019B60004B01A /* UserModel.swift */; };
+		902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902D77032C278D9400F7B462 /* CustomToggleStyle.swift */; };
 		9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */; };
 		9072AFC72BE9C46E00DE6FEB /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC62BE9C46E00DE6FEB /* EntryView.swift */; };
 		9072AFC92BE9C47000DE6FEB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9072AFC82BE9C47000DE6FEB /* Assets.xcassets */; };
@@ -84,6 +85,7 @@
 		902C01F92BF017660004B01A /* ReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptView.swift; sourceTree = "<group>"; };
 		902C01FB2BF019770004B01A /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		902C01FD2BF019B60004B01A /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
+		902D77032C278D9400F7B462 /* CustomToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggleStyle.swift; sourceTree = "<group>"; };
 		9072AFC12BE9C46E00DE6FEB /* FairShare.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FairShare.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FairShareApp.swift; sourceTree = "<group>"; };
 		9072AFC62BE9C46E00DE6FEB /* EntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryView.swift; sourceTree = "<group>"; };
@@ -161,6 +163,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		902D77052C279E9400F7B462 /* Elements */ = {
+			isa = PBXGroup;
+			children = (
+				902D77032C278D9400F7B462 /* CustomToggleStyle.swift */,
+			);
+			path = Elements;
+			sourceTree = "<group>";
+		};
 		9072AFB82BE9C46E00DE6FEB = {
 			isa = PBXGroup;
 			children = (
@@ -271,6 +281,7 @@
 				909E69992C02C5F7009D00D6 /* Authentication */,
 				909E69982C02C5C7009D00D6 /* Receipt */,
 				909E69972C02C5B9009D00D6 /* Profile */,
+				902D77052C279E9400F7B462 /* Elements */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -492,6 +503,7 @@
 				90FB96292BF0321C0061E83D /* InputView.swift in Sources */,
 				90F476212C1581950075B36B /* ReceiptCardView.swift in Sources */,
 				902C01FE2BF019B60004B01A /* UserModel.swift in Sources */,
+				902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */,
 				90F5749F2BF93BCC005A9A2E /* MainTabView.swift in Sources */,
 				90FB96152BF020490061E83D /* ReceiptModel.swift in Sources */,
 				90FB962F2BF0779B0061E83D /* SettingsRowView.swift in Sources */,

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -71,16 +71,6 @@ struct Strings {
 		static let profileTab = TextAsset(string: "Profile")
 	}
 
-	struct ReceiptView {
-		static let navigationTitle = TextAsset(string: "Receipt History")
-		static let emptyState = TextAsset(string: "Click the + to add a new receipt")
-	}
-
-	struct ReceiptCardView {
-		static let dateTitle = TextAsset(string: "Date:")
-		static let creatorTitle = TextAsset(string: "Created by:")
-	}
-
 	struct NewReceiptView {
 		static let navigationTitle = TextAsset(string: "New Receipt")
 		static let editButton = TextAsset(string: "Edit")
@@ -97,6 +87,16 @@ struct Strings {
 		static let account = "Account"
 		static let delete = "Delete Account"
 		static let signOut = "Sign Out"
+	}
+
+	struct ReceiptCardView {
+		static let dateTitle = TextAsset(string: "Date:")
+		static let creatorTitle = TextAsset(string: "Created by:")
+	}
+
+	struct ReceiptView {
+		static let navigationTitle = TextAsset(string: "Receipt History")
+		static let emptyState = TextAsset(string: "Click the + to add a new receipt")
 	}
 }
 

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -120,6 +120,8 @@ struct Constants {
 		static let CreatorIDKey = "creatorID"
 		static let DateKey = "date"
 		static let ImageURLKey = "imageURL"
+		static let ItemsKey = "items"
+
 	}
 
 	struct StorageKeys {

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -94,6 +94,12 @@ struct Strings {
 		static let creatorTitle = TextAsset(string: "Created by:")
 	}
 
+	struct ReceiptDetailView {
+		static let defaultToggleTitle = TextAsset(string: "Full Receipt")
+		static let onToggleTitle = TextAsset(string: "Self Only")
+		static let imagesSectionTitle = TextAsset(string: "Images")
+	}
+
 	struct ReceiptView {
 		static let navigationTitle = TextAsset(string: "Receipt History")
 		static let emptyState = TextAsset(string: "Click the + to add a new receipt")

--- a/FairShare/Helpers/Extensions/Date+Helper.swift
+++ b/FairShare/Helpers/Extensions/Date+Helper.swift
@@ -9,8 +9,10 @@ import Foundation
 
 extension Date {
 	enum DateFormatType: String {
-		case full = "MMMM dd hh:mm a"
+		case dateTime = "MMMM dd hh:mm a"
 		case standard = "MMMM dd"
+		case full = "MMMM d, yyyy"
+
 	}
 
 	static func getISOTimestamp() -> String {
@@ -19,7 +21,7 @@ extension Date {
 		return timestamp
 	}
 
-	func toString(format: DateFormatType = .standard) -> String {
+	func toString(_ format: DateFormatType = .standard) -> String {
 		let dateFormatter = DateFormatter()
 		dateFormatter.dateFormat = format.rawValue
 		return dateFormatter.string(from: self)

--- a/FairShare/Models/ReceiptModel.swift
+++ b/FairShare/Models/ReceiptModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ReceiptModel: Identifiable, Codable {
+struct ReceiptModel: Identifiable, Codable, Hashable {
 	var id: UUID
 	var creator: UserModel
 	var date: Date
@@ -21,7 +21,31 @@ struct ReceiptModel: Identifiable, Codable {
 		self.imageURL = imageURL
 	}
 
-	static let dummyData: ReceiptModel = ReceiptModel(id: UUID(), creator: UserModel.dummyData, date: Date(), imageURL: "https://picsum.photos/200/300")
+	static func == (lhs: ReceiptModel, rhs: ReceiptModel) -> Bool {
+		lhs.id == rhs.id
+	}
+
+	func hash(into hasher: inout Hasher) {
+			hasher.combine(id)
+		}
+}
+
+extension ReceiptModel {
+	static let dummyData: ReceiptModel = dummyArrayData[0]
+	static let dummyArrayData: [ReceiptModel] = [
+		ReceiptModel(
+			id: UUID(),
+			creator: UserModel.dummyData,
+			date: Date(),
+			imageURL: "https://picsum.photos/200/300"
+		),
+		ReceiptModel(
+			id: UUID(),
+			creator: UserModel.dummyArrayData[1],
+			date: Date(),
+			imageURL: "https://picsum.photos/200/300"
+		)
+	]
 }
 
 protocol ReceiptText: Identifiable, Comparable {
@@ -41,10 +65,9 @@ class ReceiptItem: ReceiptText {
 		self.cost = cost
 	}
 
-	var costAsCurrency: String {
-		return String(format: "$%.02f", self.cost)
-
-	}
+	func hash(into hasher: inout Hasher) {
+			hasher.combine(id)
+		}
 
 	static func == (lhs: ReceiptItem, rhs: ReceiptItem) -> Bool {
 		return lhs.id == rhs.id && lhs.title == rhs.title && lhs.cost == rhs.cost
@@ -54,6 +77,39 @@ class ReceiptItem: ReceiptText {
 	static func < (lhs: ReceiptItem, rhs: ReceiptItem) -> Bool {
 		return lhs.id < rhs.id
 	}
+}
+
+extension ReceiptItem {
+	var costAsCurrency: String {
+		return String(format: "$%.02f", self.cost)
+
+	}
+
+	static let dummyData: ReceiptItem = dummyArrayData[0]
+	static let dummyArrayData: [ReceiptItem] = [
+		ReceiptItem(
+			title: "Apple",
+			cost: 1.99
+		),
+		ReceiptItem(
+			title: "Banana",
+			cost: 0.99
+		),
+		ReceiptItem(
+			title: "Orange",
+			cost: 1.49
+		),
+		ReceiptItem(
+			title: "Tax",
+			cost: 0.40,
+			type: .tax
+		),
+		ReceiptItem(
+			title: "Total",
+			cost: 4.87,
+			type: .total
+		)
+	]
 }
 
 class ReceiptInformation: ReceiptText {

--- a/FairShare/Models/ReceiptModel.swift
+++ b/FairShare/Models/ReceiptModel.swift
@@ -12,6 +12,8 @@ struct ReceiptModel: Identifiable, Codable, Hashable {
 	var creator: UserModel
 	var date: Date
 	var imageURL: String
+	//TODO: update items to [any ReceiptText]
+//	var items: [ReceiptItem]
 	//TODO: add guest IDs to display receipt for all guests as well
 
 	init(id: UUID, creator: UserModel, date: Date, imageURL: String) {
@@ -51,18 +53,30 @@ extension ReceiptModel {
 protocol ReceiptText: Identifiable, Comparable {
 	var id: UUID { get }
 	var title: String { get set }
+
+	func toDictionary() -> [String: Any]
 }
 
-class ReceiptItem: ReceiptText {
+enum ReceiptItemType: String, CaseIterable {
+	case item
+	case tax
+	case tip
+	case total
+	case subTotal
+}
+
+class ReceiptItem: ReceiptText, Hashable {
 	//TODO: add user IDs [String] for people responsible for item
 	let id: UUID
 	var title: String
 	var cost: Double
+	var type: ReceiptItemType
 
-	init(id: UUID = UUID(), title: String, cost: Double) {
+	init(id: UUID = UUID(), title: String, cost: Double, type: ReceiptItemType = .item) {
 		self.id = id
 		self.title = title
 		self.cost = cost
+		self.type = type
 	}
 
 	func hash(into hasher: inout Hasher) {
@@ -84,6 +98,15 @@ extension ReceiptItem {
 		return String(format: "$%.02f", self.cost)
 
 	}
+
+	func toDictionary() -> [String: Any] {
+			return [
+				"id": id.uuidString,
+				"title": title,
+				"cost": cost,
+				"type": type.rawValue
+			]
+		}
 
 	static let dummyData: ReceiptItem = dummyArrayData[0]
 	static let dummyArrayData: [ReceiptItem] = [
@@ -128,5 +151,13 @@ class ReceiptInformation: ReceiptText {
 	static func < (lhs: ReceiptInformation, rhs: ReceiptInformation) -> Bool {
 		return lhs.id < rhs.id
 	}
+}
 
+extension ReceiptInformation {
+	func toDictionary() -> [String : Any] {
+		return [
+			"id": id.uuidString,
+			"title": title
+		]
+	}
 }

--- a/FairShare/Models/UserModel.swift
+++ b/FairShare/Models/UserModel.swift
@@ -7,13 +7,15 @@
 
 import Foundation
 
-struct UserModel: Identifiable, Codable {
+struct UserModel: Identifiable, Codable, Hashable {
 	var id: String
 	var firstName: String
 	var lastName: String
 	var email: String
 	//TODO: active user can create "guest" user by phone number. If this guest makes an account later, they can be linked to their guest account and updated via matching phone number.
+}
 
+extension UserModel {
 	var initials: String {
 		let formatter = PersonNameComponentsFormatter()
 		if let components = formatter.personNameComponents(from: "\(firstName) \(lastName)") {
@@ -32,6 +34,19 @@ struct UserModel: Identifiable, Codable {
 		return "\(firstName) \(lastName.prefix(1))."
 	}
 
-	static let dummyData: UserModel = UserModel(id: UUID().uuidString, firstName: "Jane", lastName: "Smith", email: "janesmith@gmail.com")
-
+	static let dummyData: UserModel = dummyArrayData[0]
+	static let dummyArrayData: [UserModel] = [
+		UserModel(
+			id: UUID().uuidString,
+			firstName: "Jane",
+			lastName: "Smith",
+			email: "janesmith@gmail.com"
+		),
+		UserModel(
+			id: UUID().uuidString,
+			firstName: "John",
+			lastName: "Williams",
+			email: "jwill@gmail.com"
+		)
+	]
 }

--- a/FairShare/Networking/DBService.swift
+++ b/FairShare/Networking/DBService.swift
@@ -70,15 +70,15 @@ extension DBService {
 			}
 
 			let imageURL = try await StorageService.postImage(imageData: imageData, imageName: Constants.ReceiptImagePath + docID.uuidString)
+			let receiptTextsData = receiptTexts.map { $0.toDictionary() }
 
 			let receiptData: [String: Any] = [
 				Constants.ReceiptCollectionKeys.DocumentIdKey: docID.uuidString,
 				Constants.ReceiptCollectionKeys.CreatorIDKey: creatorID,
 				Constants.ReceiptCollectionKeys.DateKey: Date(),
-				Constants.ReceiptCollectionKeys.ImageURLKey: imageURL.absoluteString
+				Constants.ReceiptCollectionKeys.ImageURLKey: imageURL.absoluteString,
+				Constants.ReceiptCollectionKeys.ItemsKey: receiptTextsData
 			]
-
-			// TODO: Add receiptTexts to receiptData
 
 			try await receiptsRef.document(docID.uuidString).setData(receiptData)
 			print("Receipt Document successfully written.")
@@ -136,6 +136,7 @@ extension DBService {
 						continue
 					}
 
+					//TODO: add items from firebase to ReceiptModel
 					let creatorSnapshot = try await firestoreDB.collection(Constants.UserCollectionKeys.CollectionKey).document(creatorID).getDocument()
 					let creator = try creatorSnapshot.data(as: UserModel.self)
 

--- a/FairShare/UI/Elements/CustomToggleStyle.swift
+++ b/FairShare/UI/Elements/CustomToggleStyle.swift
@@ -1,0 +1,43 @@
+//
+//  CustomToggleStyle.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/22/24.
+//
+
+import SwiftUI
+
+struct CustomToggleStyle: ToggleStyle {
+	var onColor: Color
+	var offColor: Color
+	var thumbColor: Color
+
+	init(onColor: Color = .green, offColor: Color = Color(.systemGray5), thumbColor: Color = .white) {
+		self.onColor = onColor
+		self.offColor = offColor
+		self.thumbColor = thumbColor
+	}
+
+	internal func makeBody(configuration: Configuration) -> some View {
+		HStack {
+			configuration.label
+
+			Spacer()
+
+			RoundedRectangle(cornerRadius: 30)
+				.fill(configuration.isOn ? onColor : offColor)
+				.overlay {
+					Circle()
+						.fill(thumbColor)
+						.padding(3)
+						.offset(x: configuration.isOn ? 9 : -9)
+				}
+				.frame(width: 50, height: 32)
+				.onTapGesture {
+					withAnimation(.smooth) {
+						configuration.isOn.toggle()
+					}
+				}
+		}
+	}
+}

--- a/FairShare/UI/Receipt/CameraView.swift
+++ b/FairShare/UI/Receipt/CameraView.swift
@@ -205,13 +205,28 @@ enum Processor {
 				let valueString = current.boundingBox.minX < next.boundingBox.minX ? candidateTwo.string : candidateOne.string
 
 				if let value = Double(valueString) {
-					receiptText.append(ReceiptItem(title: key, cost: value))
+					let type: ReceiptItemType = {
+						if key.lowercased() == "tax" {
+							return .tax
+						} else if key.lowercased() == "tip" {
+							return .tip
+						} else if key.lowercased() == "sub total" {
+							return .subTotal
+						} else if key.lowercased() == "total" {
+							return .total
+						} else {
+							return .item
+						}
+					}()
+
+					receiptText.append(ReceiptItem(title: key, cost: value, type: type))
 				}
 				index += 2
 			} else {
-				let title = candidateOne.string
-				receiptText.append(ReceiptInformation(title: title))
-
+				//TODO: reintroduce ReceiptInformation
+//				let title = candidateOne.string
+//				receiptText.append(ReceiptInformation(title: title))
+//
 				index += 1
 			}
 		}

--- a/FairShare/UI/Receipt/EditableReceiptItemView.swift
+++ b/FairShare/UI/Receipt/EditableReceiptItemView.swift
@@ -36,5 +36,5 @@ struct EditableReceiptItemView: View {
 }
 
 #Preview {
-	EditableReceiptItemView(item: .constant(ReceiptItem(title: "Apple", cost: 1.99)))
+	EditableReceiptItemView(item: .constant(ReceiptItem.dummyData))
 }

--- a/FairShare/UI/Receipt/ReceiptCardView.swift
+++ b/FairShare/UI/Receipt/ReceiptCardView.swift
@@ -30,9 +30,13 @@ struct ReceiptCardView: View {
 			}
 		}
 		.padding(.all, 10)
-		.background(Color(.systemGray6))
 		.cornerRadius(8)
-		.shadow(radius: 2)
+		.background(Color(.systemGray6))
+		.background(
+			RoundedRectangle(cornerRadius: 8)
+				.shadow(radius: 2)
+				.padding(1)
+		)
 	}
 }
 

--- a/FairShare/UI/Receipt/ReceiptDetailView.swift
+++ b/FairShare/UI/Receipt/ReceiptDetailView.swift
@@ -1,0 +1,82 @@
+//
+//  ReceiptDetailView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/22/24.
+//
+
+import SwiftUI
+
+struct ReceiptDetailView: View {
+	var receipt: ReceiptModel
+	@State private var isEnabled = false
+	//TODO: Replace static data with fetched receipt
+	@State private var items: [ReceiptItem] = ReceiptItem.dummyArrayData
+
+	private func itemsByType() -> [[ReceiptItem]] {
+		guard !items.isEmpty else { return [] }
+		let dictionaryByType = Dictionary(grouping: items, by: { $0.type })
+		let itemTypes = ReceiptItemType.allCases
+		return itemTypes.compactMap({ dictionaryByType[$0] })
+	}
+
+	var body: some View {
+		VStack(spacing: 0) {
+				Toggle(isOn: $isEnabled) {
+					Text(isEnabled ? Strings.ReceiptDetailView.onToggleTitle.string : Strings.ReceiptDetailView.defaultToggleTitle.string)
+						.font(.headline)
+				}
+				.toggleStyle(CustomToggleStyle())
+				.padding(.horizontal)
+				.padding(.bottom, 5)
+
+			GeometryReader { geometry in
+				List {
+					ForEach(itemsByType(), id: \.self) { itemInType in
+						Section(header: Text(itemInType[0].type.rawValue)) {
+							ForEach(itemInType) { item in
+								HStack {
+									Text(item.title)
+									Spacer()
+									Text(item.costAsCurrency)
+								}
+							}
+						}
+					}
+					Section(header: Strings.ReceiptDetailView.imagesSectionTitle.text) {
+						HStack {
+							//TODO: add download option for images or whole breakdown
+							//TODO: convert to carousel for multiple images
+							Spacer()
+							AsyncImage(url: URL(string: receipt.imageURL)) { phase in
+								switch phase {
+								case .empty:
+									ProgressView()
+								case .success(let image):
+									image.resizable()
+										.aspectRatio(contentMode: .fit)
+										.frame(width: geometry.size.width * 0.5, height: geometry.size.height * 0.5)
+								case .failure:
+									EmptyView()
+								@unknown default:
+									EmptyView()
+								}
+							}
+
+							Spacer()
+						}
+						.frame(height: geometry.size.height * 0.5)
+						.background(Color(.systemGray5))
+					}
+				}
+				.listSectionSpacing(0)
+				.navigationTitle(receipt.date.toString(.full))
+				.navigationBarTitleDisplayMode(.inline)
+			}
+		}
+	}
+}
+
+#Preview {
+	ReceiptDetailView(receipt: ReceiptModel.dummyData)
+}

--- a/FairShare/UI/Receipt/ReceiptItemsView.swift
+++ b/FairShare/UI/Receipt/ReceiptItemsView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-//TODO rename ReceiptTextView
+//TODO: rename ReceiptTextView
 struct ReceiptItemsView: View {
 	@Binding var receiptTexts: [any ReceiptText]
 	@Binding var isEditing: Bool
@@ -40,9 +40,6 @@ struct ReceiptItemsView: View {
 
 #Preview {
 	ReceiptItemsView(receiptTexts: .constant([
-		ReceiptInformation(title: "Fruit Shop"),
-		ReceiptItem(title: "Apple", cost: 1.99),
-		ReceiptItem(title: "Banana", cost: 0.99),
-		ReceiptItem(title: "Orange", cost: 1.49)
-	]), isEditing: .constant(false))
+		ReceiptInformation(title: "Fruit Shop")] + ReceiptItem.dummyArrayData
+	), isEditing: .constant(true))
 }

--- a/FairShare/UI/Receipt/ReceiptView.swift
+++ b/FairShare/UI/Receipt/ReceiptView.swift
@@ -6,13 +6,11 @@
 //
 
 import Firebase
-import PhotosUI
 import SwiftUI
 
 struct ReceiptView: View {
 	@EnvironmentObject var authViewModel: AuthViewModel
-	
-	@State private var selectedReceipt: ReceiptModel? = nil
+
 	@State private var isPresented = false
 
 	var body: some View {
@@ -23,13 +21,16 @@ struct ReceiptView: View {
 						.progressViewStyle(CircularProgressViewStyle())
 						.scaleEffect(1.5, anchor: .center)
 				} else {
-					//TODO: Update to ScrollView+LazyVStack to handle larger lists and account for spacing.
-					List(authViewModel.receipts, id: \.id) { receipt in
-						ReceiptCardView(receipt: receipt)
-							.listRowSeparator(.hidden)
-							.onTapGesture {
-								selectedReceipt = receipt
+					ScrollView {
+						LazyVStack(spacing: 10) {
+							ForEach(authViewModel.receipts, id: \.id) { receipt in
+								NavigationLink(value: receipt) {
+									ReceiptCardView(receipt: receipt)
+								}
+								.foregroundColor(.black)
 							}
+						}
+						.padding()
 					}
 					.overlay(
 						Group {
@@ -40,10 +41,9 @@ struct ReceiptView: View {
 					)
 				}
 			}
+			.navigationTitle(Strings.ReceiptView.navigationTitle.text)
+			.navigationBarTitleDisplayMode(.inline)
 			.toolbar {
-				ToolbarItem(placement: .principal) {
-					Strings.ReceiptView.navigationTitle.text.font(.headline)
-				}
 				ToolbarItem(placement: .topBarTrailing) {
 					Button {
 						isPresented.toggle()
@@ -52,9 +52,12 @@ struct ReceiptView: View {
 					}
 				}
 			}
-		}
-		.fullScreenCover(isPresented: $isPresented) {
-			NewReceiptView()
+			.fullScreenCover(isPresented: $isPresented) {
+				NewReceiptView()
+			}
+			.navigationDestination(for: ReceiptModel.self) { receipt in
+				ReceiptDetailView(receipt: receipt)
+			}
 		}
 	}
 }


### PR DESCRIPTION
In this PR I have (in order of commits):
- Refactored `ReceiptModel`, `UserModel`, and `Constants` files to better organize data.
- Updated code to remove a runtime warning coming from `ReceiptCardView`.
- Added the ability to upload `ReceiptItem` data to `Firestore Database` .
- Created a `CustomToggleStyle` for use within the `ReceiptDetailView`.
- Created a `ReceiptDetailView` that is viewed when a user taps on any receipt in their history from `ReceiptView`. Currently I am using dummy data for this view. Once I am able to decode the `ReceiptItem` data from `Firestore Database` the dummy data will be replaced. This has been tagged with a `TODO`.

`ReceiptDetailView` segue with dummy data Screenshot(iPhone 15 Pro):

<img src="https://github.com/SLRAM/FairShare/assets/28938900/18730185-bd08-4e5e-a95f-b5dcb9163ee1" width="184" height="400">


ReceiptItem `Firestore Database` Screenshot(Firebase):

<img src="https://github.com/SLRAM/FairShare/assets/28938900/c249f229-0fb7-4926-af6f-96367dfe5fef" width="1000" height="500">

Next Goals:
- Account for `TODO` notes in code.
- Finish updating error handling for `DBService`.
- Dismiss `NewReceiptView` if user cancels `CameraView` or `PhotosPicker`.
- Fetch `ReceiptItems` from Firebase.