### PR TITLE
[ReceiptItem, ContactModel] fetch/display receipt items and upload/fetch user contacts

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9005BDC72BF9606B00039D00 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9005BDC62BF9606B00039D00 /* Launch Screen.storyboard */; };
+		9029DF162C31422B008586E6 /* NewReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */; };
 		902C01CD2BF008060004B01A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01CC2BF008060004B01A /* FirebaseAnalytics */; };
 		902C01CF2BF008060004B01A /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01CE2BF008060004B01A /* FirebaseAnalyticsSwift */; };
 		902C01D12BF008060004B01A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01D02BF008060004B01A /* FirebaseAuth */; };
@@ -82,6 +83,7 @@
 
 /* Begin PBXFileReference section */
 		9005BDC62BF9606B00039D00 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewReceiptViewModel.swift; sourceTree = "<group>"; };
 		902C01F52BF00B0E0004B01A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		902C01F92BF017660004B01A /* ReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptView.swift; sourceTree = "<group>"; };
 		902C01FB2BF019770004B01A /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
@@ -252,6 +254,7 @@
 				902D77012C27766800F7B462 /* ReceiptDetailView.swift */,
 				90F476202C1581950075B36B /* ReceiptCardView.swift */,
 				90FB96182BF029190061E83D /* NewReceiptView.swift */,
+				9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */,
 				909E69932C02A5C7009D00D6 /* CameraView.swift */,
 				90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */,
 				90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */,
@@ -528,6 +531,7 @@
 				902C01FA2BF017660004B01A /* ReceiptView.swift in Sources */,
 				902D77022C27766800F7B462 /* ReceiptDetailView.swift in Sources */,
 				90FB96272BF030B20061E83D /* LoginView.swift in Sources */,
+				9029DF162C31422B008586E6 /* NewReceiptViewModel.swift in Sources */,
 				9072AFD12BE9C47000DE6FEB /* FairShare.xcdatamodeld in Sources */,
 				90F4761D2C14F6510075B36B /* DBService.swift in Sources */,
 			);

--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9005BDC72BF9606B00039D00 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9005BDC62BF9606B00039D00 /* Launch Screen.storyboard */; };
 		9029DF162C31422B008586E6 /* NewReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */; };
+		9029DF182C314475008586E6 /* ContactModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9029DF172C314475008586E6 /* ContactModel.swift */; };
 		902C01CD2BF008060004B01A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01CC2BF008060004B01A /* FirebaseAnalytics */; };
 		902C01CF2BF008060004B01A /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01CE2BF008060004B01A /* FirebaseAnalyticsSwift */; };
 		902C01D12BF008060004B01A /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01D02BF008060004B01A /* FirebaseAuth */; };
@@ -84,6 +85,7 @@
 /* Begin PBXFileReference section */
 		9005BDC62BF9606B00039D00 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
 		9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewReceiptViewModel.swift; sourceTree = "<group>"; };
+		9029DF172C314475008586E6 /* ContactModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactModel.swift; sourceTree = "<group>"; };
 		902C01F52BF00B0E0004B01A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		902C01F92BF017660004B01A /* ReceiptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptView.swift; sourceTree = "<group>"; };
 		902C01FB2BF019770004B01A /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 			children = (
 				90FB96142BF020490061E83D /* ReceiptModel.swift */,
 				902C01FD2BF019B60004B01A /* UserModel.swift */,
+				9029DF172C314475008586E6 /* ContactModel.swift */,
 				902C01FB2BF019770004B01A /* AuthViewModel.swift */,
 			);
 			path = Models;
@@ -533,6 +536,7 @@
 				90FB96272BF030B20061E83D /* LoginView.swift in Sources */,
 				9029DF162C31422B008586E6 /* NewReceiptViewModel.swift in Sources */,
 				9072AFD12BE9C47000DE6FEB /* FairShare.xcdatamodeld in Sources */,
+				9029DF182C314475008586E6 /* ContactModel.swift in Sources */,
 				90F4761D2C14F6510075B36B /* DBService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		9005BDC72BF9606B00039D00 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9005BDC62BF9606B00039D00 /* Launch Screen.storyboard */; };
+		9029DF142C3140A2008586E6 /* ContactPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9029DF132C3140A2008586E6 /* ContactPickerView.swift */; };
 		9029DF162C31422B008586E6 /* NewReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */; };
 		9029DF182C314475008586E6 /* ContactModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9029DF172C314475008586E6 /* ContactModel.swift */; };
 		902C01CD2BF008060004B01A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 902C01CC2BF008060004B01A /* FirebaseAnalytics */; };
@@ -84,6 +85,7 @@
 
 /* Begin PBXFileReference section */
 		9005BDC62BF9606B00039D00 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		9029DF132C3140A2008586E6 /* ContactPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPickerView.swift; sourceTree = "<group>"; };
 		9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewReceiptViewModel.swift; sourceTree = "<group>"; };
 		9029DF172C314475008586E6 /* ContactModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactModel.swift; sourceTree = "<group>"; };
 		902C01F52BF00B0E0004B01A /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -244,6 +246,7 @@
 			isa = PBXGroup;
 			children = (
 				90FB962C2BF0753E0061E83D /* ProfileView.swift */,
+				9029DF132C3140A2008586E6 /* ContactPickerView.swift */,
 				90FB962E2BF0779B0061E83D /* SettingsRowView.swift */,
 			);
 			path = Profile;
@@ -513,6 +516,7 @@
 				90F476212C1581950075B36B /* ReceiptCardView.swift in Sources */,
 				902C01FE2BF019B60004B01A /* UserModel.swift in Sources */,
 				902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */,
+				9029DF142C3140A2008586E6 /* ContactPickerView.swift in Sources */,
 				90F5749F2BF93BCC005A9A2E /* MainTabView.swift in Sources */,
 				90FB96152BF020490061E83D /* ReceiptModel.swift in Sources */,
 				90FB962F2BF0779B0061E83D /* SettingsRowView.swift in Sources */,
@@ -705,6 +709,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app needs to capture images of your receipt";
+				INFOPLIST_KEY_NSContactsUsageDescription = "Allow Contact Access";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -736,6 +741,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "This app needs to capture images of your receipt";
+				INFOPLIST_KEY_NSContactsUsageDescription = "Allow Contact Access";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -42,6 +42,7 @@ struct Images {
 		static let personCropCircle = ImageAsset(name: "person.crop.circle", isSystem: true)
 		static let plus = ImageAsset(name: "plus", isSystem: true)
 		static let xMarkCircleFill = ImageAsset(name: "xmark.circle.fill", isSystem: true)
+		static let listBulletCircleFill = ImageAsset(name: "list.bullet.circle.fill", isSystem: true)
 	}
 }
 
@@ -85,8 +86,11 @@ struct Strings {
 
 	struct ProfileView {
 		static let account = "Account"
+		static let contacts = "Contacts"
 		static let delete = "Delete Account"
 		static let signOut = "Sign Out"
+		static let addContacts = "Add Contacts"
+		static let viewContacts = "View Contacts"
 	}
 
 	struct ReceiptCardView {

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -127,10 +127,17 @@ struct Constants {
 		static let DateKey = "date"
 		static let ImageURLKey = "imageURL"
 		static let ItemsKey = "items"
-
 	}
 
 	struct StorageKeys {
 		static let ImagesKey = "images"
+	}
+
+	struct ContactCollectionKeys {
+		static let CollectionKey = "contacts"
+		static let DocumentIdKey = "id"
+		static let FirstNameKey = "firstName"
+		static let LastNameKey = "lastName"
+		static let PhoneNumberKey = "phoneNumber"
 	}
 }

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -124,5 +124,17 @@ extension AuthViewModel {
 	}
 }
 
+///Contacts
+extension AuthViewModel {
+	func addContacts(contacts: [ContactModel]) async throws {
+		do {
+			for contact in contacts {
+				try await DBService.addContact(contact: contact, creatorID: self.currentUser!.id)
+			}
+		} catch {
+			print("Error writing document: \(error)")
+			throw error
+		}
+	}
 	}
 }

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -14,6 +14,7 @@ class AuthViewModel: ObservableObject {
 	@Published var userSession: FirebaseAuth.User?
 	@Published var currentUser: UserModel?
 	@Published var receipts: [ReceiptModel] = []
+	@Published var contacts: [ContactModel] = []
 	@Published var showAlert = false
 	@Published var errorMessage: String = ""
 	@Published var isLoading: Bool = true
@@ -87,6 +88,7 @@ extension AuthViewModel {
 			let fetchedUser = try await DBService.fetchUser(userId: userId)
 			self.currentUser = fetchedUser
 			try await self.fetchUserReceipts()
+			try await self.fetchContacts()
 		} catch {
 			print("Error fetching user: \(error)")
 			throw error
@@ -136,5 +138,19 @@ extension AuthViewModel {
 			throw error
 		}
 	}
+
+	func fetchContacts() async throws {
+		guard let userID = self.currentUser?.id else {
+			print("Error: Current user ID is nil.")
+			return
+		}
+
+		do {
+			let fetchedContacts = try await DBService.fetchUserContacts(userID: userID)
+			self.contacts = fetchedContacts.sorted { $0.firstName > $1.firstName }
+		} catch {
+			print("Error fetching user contacts: \(error)")
+			throw error
+		}
 	}
 }

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -26,6 +26,14 @@ class AuthViewModel: ObservableObject {
 		}
 	}
 
+	private func showError(for message: String) {
+		errorMessage = message
+		showAlert = true
+	}
+}
+
+///Authentication
+extension AuthViewModel {
 	func signIn(with email: String, password: String) async throws {
 		do {
 			let result = try await AuthService.signIn(with: email, password: password)
@@ -84,7 +92,10 @@ class AuthViewModel: ObservableObject {
 			throw error
 		}
 	}
+}
 
+///Receipt
+extension AuthViewModel {
 	func fetchUserReceipts() async throws {
 		guard let userID = self.currentUser?.id else {
 			print("Error: Current user ID is nil.")
@@ -111,9 +122,7 @@ class AuthViewModel: ObservableObject {
 			throw error
 		}
 	}
+}
 
-	private func showError(for message: String) {
-		errorMessage = message
-		showAlert = true
 	}
 }

--- a/FairShare/Models/ContactModel.swift
+++ b/FairShare/Models/ContactModel.swift
@@ -1,0 +1,40 @@
+//
+//  ContactModel.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/30/24.
+//
+
+import Foundation
+
+struct ContactModel: Identifiable, Codable, Hashable {
+	var id: String
+	var firstName: String
+	var lastName: String
+	var phoneNumber: String
+
+	init(id: String = UUID().uuidString, firstName: String, lastName: String, phoneNumber: String) {
+		self.id = id
+		self.firstName = firstName
+		self.lastName = lastName
+		self.phoneNumber = phoneNumber
+	}
+
+	//TODO: active user can create "guest" contact by phone number. If this contact makes an account later, they can be linked to their guest account and updated via matching phone number.
+
+	static let dummyData: ContactModel = dummyArrayData[0]
+	static let dummyArrayData: [ContactModel] = [
+		ContactModel(
+			id: UUID().uuidString,
+			firstName: "John",
+			lastName: "Appleseed",
+			phoneNumber: "8885555512"
+		),
+		ContactModel(
+			id: UUID().uuidString,
+			firstName: "Kate",
+			lastName: "Bell",
+			phoneNumber: "5555648583"
+		)
+	]
+}

--- a/FairShare/Models/UserModel.swift
+++ b/FairShare/Models/UserModel.swift
@@ -12,7 +12,7 @@ struct UserModel: Identifiable, Codable, Hashable {
 	var firstName: String
 	var lastName: String
 	var email: String
-	//TODO: active user can create "guest" user by phone number. If this guest makes an account later, they can be linked to their guest account and updated via matching phone number.
+	//TODO: add phone number.
 }
 
 extension UserModel {

--- a/FairShare/UI/Main/MainTabView.swift
+++ b/FairShare/UI/Main/MainTabView.swift
@@ -19,6 +19,7 @@ struct MainTabView: View {
 						icon: { Images.System.listDash.image }
 					)
 				}
+			
 			ProfileView()
 				.tabItem {
 					Label(

--- a/FairShare/UI/Profile/ContactPickerView.swift
+++ b/FairShare/UI/Profile/ContactPickerView.swift
@@ -1,0 +1,65 @@
+//
+//  ContactPickerView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/30/24.
+//
+
+import Contacts
+import ContactsUI
+import SwiftUI
+
+struct ContactPickerView: UIViewControllerRepresentable {
+	@Binding var selectedContacts: [ContactModel]
+
+	func makeUIViewController(context: Context) -> CNContactPickerViewController {
+		let picker = CNContactPickerViewController()
+		picker.delegate = context.coordinator
+		return picker
+	}
+
+	func updateUIViewController(_ uiViewController: CNContactPickerViewController, context: Context) {}
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator(selectedContacts: $selectedContacts)
+	}
+
+	class Coordinator: NSObject, CNContactPickerDelegate {
+		@Binding var selectedContacts: [ContactModel]
+
+		init(selectedContacts: Binding<[ContactModel]>) {
+			_selectedContacts = selectedContacts
+		}
+
+		func contactPicker(_ picker: CNContactPickerViewController, didSelect contacts: [CNContact]) {
+			var newContacts: [ContactModel] = []
+
+			for contact in contacts {
+				let phoneNumber: String = {
+					var phone = String()
+
+					for phoneNumber in contact.phoneNumbers {
+						let strippedNumber = phoneNumber.value.stringValue.components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+						phone = strippedNumber
+						break
+					}
+
+					return phone
+				}()
+
+				let model = ContactModel(
+					firstName: contact.givenName,
+					lastName: contact.familyName,
+					phoneNumber: phoneNumber
+				)
+
+				newContacts.append(model)
+			}
+
+			selectedContacts = newContacts
+		}
+
+		func contactPickerDidCancel(_ picker: CNContactPickerViewController) {
+		}
+	}
+}

--- a/FairShare/UI/Profile/ProfileView.swift
+++ b/FairShare/UI/Profile/ProfileView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct ProfileView: View {
 	@EnvironmentObject var viewModel: AuthViewModel
+	@State private var showContactPicker = false
+	@State private var selectedContacts: [ContactModel] = []
+
 	var body: some View {
 		if let user = viewModel.currentUser {
 			List {
@@ -49,6 +52,26 @@ struct ProfileView: View {
 					} label: {
 						SettingsRowView(rowType: .delete)
 					}
+				}
+
+				Section(Strings.ProfileView.contacts) {
+					//TODO: add view Contacts to allow for edits.
+					Button {
+						showContactPicker.toggle()
+					} label: {
+						SettingsRowView(rowType: .contacts)
+					}
+				}
+			}
+			.fullScreenCover(
+				isPresented: $showContactPicker,
+				content: {
+					ContactPickerView(selectedContacts: $selectedContacts)
+				}
+			)
+			.onChange(of: selectedContacts) {
+				Task {
+					try await viewModel.addContacts(contacts: selectedContacts)
 				}
 			}
 		}

--- a/FairShare/UI/Profile/SettingsRowView.swift
+++ b/FairShare/UI/Profile/SettingsRowView.swift
@@ -11,6 +11,7 @@ struct SettingsRowView: View {
 	enum RowType {
 		case signOut
 		case delete
+		case contacts
 
 		var image: Image {
 			switch self {
@@ -18,6 +19,8 @@ struct SettingsRowView: View {
 				return Images.System.arrowLeftCircleFill.image
 			case .delete:
 				return Images.System.xMarkCircleFill.image
+			case .contacts:
+				return Images.System.listBulletCircleFill.image
 			}
 		}
 
@@ -27,6 +30,8 @@ struct SettingsRowView: View {
 				return Strings.ProfileView.signOut
 			case .delete:
 				return Strings.ProfileView.delete
+			case .contacts:
+				return Strings.ProfileView.addContacts
 			}
 		}
 
@@ -34,6 +39,8 @@ struct SettingsRowView: View {
 			switch self {
 			case .signOut, .delete:
 				return Color.red
+			case .contacts:
+				return Color.green
 			}
 		}
 	}

--- a/FairShare/UI/Receipt/NewReceiptView.swift
+++ b/FairShare/UI/Receipt/NewReceiptView.swift
@@ -12,95 +12,72 @@ import SwiftUI
 struct NewReceiptView: View {
 	@Environment(\.dismiss) var dismiss
 	@EnvironmentObject var authViewModel: AuthViewModel
-
-	@State private var showActionSheet = true
-	@State private var showCamera = false
-	@State private var showGallery = false
-	@State private var selectedImage: UIImage?
-	@State private var selectedItem: PhotosPickerItem?
-//	@State private var receiptItems: [ReceiptItem] = []
-	@State private var receiptTexts: [any ReceiptText] = []
-
-	@State private var isEditing = false
-	@State private var showReceiptTab: Bool = false
-
-	//TODO: remove imageToDisplay and visualizedImage. For testing purposes only.
-	@State private var imageToDisplay: Image?
-	@State private var visualizedImage: UIImage?
+	@StateObject private var viewModel = NewReceiptViewModel()
 
 	var body: some View {
 		NavigationStack {
-			//TODO: remove imageToDisplay. For testing purposes only.
-//			if let currentImage = imageToDisplay {
-//				currentImage
-//					.resizable()
-//					.scaledToFit()
-//					.frame(width: 300, height: 300)
-//				ShareLink(item: currentImage, preview: SharePreview("Current Image", image: currentImage))
-//			}
-			
-			ReceiptItemsView(receiptTexts: $receiptTexts, isEditing: $isEditing)
-				.navigationBarTitleDisplayMode(.automatic)
+			VStack {
+				ReceiptItemsView(
+					itemsByType: viewModel.itemsByType(),
+					isEditing: $viewModel.isEditing,
+					receiptTexts: $viewModel.receiptTexts,
+					itemTapped: viewModel.itemTapped,
+					imageToDisplay: viewModel.imageToDisplay
+				)
 				.toolbar {
-					ToolbarItem(placement: .principal) {
-						Strings.NewReceiptView.navigationTitle.text.font(.headline)
-					}
-					if !receiptTexts.isEmpty {
+					if !viewModel.receiptTexts.isEmpty {
 						ToolbarItem(placement: .topBarTrailing) {
-							Button {
-								isEditing.toggle()
+							Button { viewModel.isEditing.toggle()
 							} label: {
 								Strings.NewReceiptView.editButton.text
 							}
 						}
 					}
 				}
-			
-			if !receiptTexts.isEmpty {
-				Button {
-					Task {
-						if let image = selectedImage {
-							try await authViewModel.createReceipt(from: receiptTexts, image: image)
-						}
-					}
 
-					dismiss()
-				} label: {
-					Strings.NewReceiptView.saveButton.text
+				if !viewModel.receiptTexts.isEmpty {
+					Button {
+						Task {
+							if let image = viewModel.selectedImage {
+								try await authViewModel.createReceipt(from: viewModel.receiptTexts, image: image)
+							}
+						}
+						dismiss()
+					} label: {
+						Strings.NewReceiptView.saveButton.text
+					}
 				}
 			}
 		}
-		.confirmationDialog("", isPresented: $showActionSheet) {
-			Button(Strings.NewReceiptView.cameraButton) { showCamera.toggle() }
-			Button(Strings.NewReceiptView.galleryButton) { showGallery.toggle() }
+		.confirmationDialog("", isPresented: $viewModel.showActionSheet) {
+			Button(Strings.NewReceiptView.cameraButton) { viewModel.showCamera.toggle() }
+			Button(Strings.NewReceiptView.galleryButton) { viewModel.showGallery.toggle() }
 			Button(Strings.NewReceiptView.cancelButton, role: .cancel) { dismiss() }
 		} message: {
 			Strings.NewReceiptView.confirmationMessage.text
 		}
 		.photosPicker(
-			isPresented: $showGallery,
-			selection: $selectedItem,
+			isPresented: $viewModel.showGallery,
+			selection: $viewModel.selectedItem,
 			matching: .any(of: [.images, .screenshots, .livePhotos])
 		)
 		.fullScreenCover(
-			isPresented: $showCamera,
+			isPresented: $viewModel.showCamera,
 			content: {
-				CameraView(recognizedTexts: self.$receiptTexts, visualizedImage: self.$visualizedImage, selectedImage: self.$selectedImage)
+				CameraView(recognizedTexts: $viewModel.receiptTexts, visualizedImage: $viewModel.visualizedImage, selectedImage: $viewModel.selectedImage)
 					.edgesIgnoringSafeArea(.all)
 			}
 		)
-		.onChange(of: selectedImage) {
-			//TODO: remove imageToDisplay. For testing purposes only.
-			///selectedImage will be saved for the final uploaded receipt.
-			if let image = selectedImage {
-				imageToDisplay = Image(uiImage: image)
+		.onChange(of: viewModel.selectedImage) {
+			if let image = viewModel.selectedImage {
+				viewModel.imageToDisplay = Image(uiImage: image)
 			}
 		}
-		.onChange(of: selectedItem) {
+		.onChange(of: viewModel.selectedItem) {
 			Task {
-				let image = await Processor.extractImage(from: selectedItem)
-				selectedImage = image
-				receiptTexts = Processor.recognizeText(from: image)
+				let image = await Processor.extractImage(from: viewModel.selectedItem)
+				viewModel.selectedImage = image
+				viewModel.receiptTexts = Processor.recognizeText(from: image)
 			}
 		}
 	}

--- a/FairShare/UI/Receipt/NewReceiptViewModel.swift
+++ b/FairShare/UI/Receipt/NewReceiptViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  NewReceiptViewModel.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 6/30/24.
+//
+
+import PhotosUI
+import SwiftUI
+
+class NewReceiptViewModel: ObservableObject {
+	@Published var showActionSheet = true
+	@Published var showCamera = false
+	@Published var showGallery = false
+	@Published var selectedImage: UIImage?
+	@Published var selectedItem: PhotosPickerItem?
+	@Published var receiptTexts: [any ReceiptText] = []
+
+	@Published var isEditing = false
+	@Published var showReceiptTab: Bool = false
+
+	@Published var imageToDisplay: Image?
+	@Published var visualizedImage: UIImage?
+
+	@Published var isEnabled = false
+
+	func itemsByType() -> [[ReceiptItem]] {
+		let receiptItems = receiptTexts.compactMap { $0 as? ReceiptItem }
+		guard !receiptItems.isEmpty else { return [] }
+		let dictionaryByType = Dictionary(grouping: receiptItems, by: { $0.type })
+		let itemTypes = ReceiptItemType.allCases
+		return itemTypes.compactMap { dictionaryByType[$0] }
+	}
+
+	func updateSelectedItem(_ newItem: PhotosPickerItem?) async {
+		selectedItem = newItem
+		if let newItem = newItem {
+			let image = await Processor.extractImage(from: newItem)
+			selectedImage = image
+			receiptTexts = Processor.recognizeText(from: image)
+		}
+	}
+
+	func updateSelectedImage(_ newImage: UIImage?) {
+		selectedImage = newImage
+		if let newImage = newImage {
+			imageToDisplay = Image(uiImage: newImage)
+		}
+	}
+
+	func itemTapped(item: ReceiptItem) {
+		//TODO: select contact to add as payer.
+		print("Item tapped: \(item.title)")
+	}
+}

--- a/FairShare/UI/Receipt/ReceiptDetailView.swift
+++ b/FairShare/UI/Receipt/ReceiptDetailView.swift
@@ -10,25 +10,23 @@ import SwiftUI
 struct ReceiptDetailView: View {
 	var receipt: ReceiptModel
 	@State private var isEnabled = false
-	//TODO: Replace static data with fetched receipt
-	@State private var items: [ReceiptItem] = ReceiptItem.dummyArrayData
 
 	private func itemsByType() -> [[ReceiptItem]] {
-		guard !items.isEmpty else { return [] }
-		let dictionaryByType = Dictionary(grouping: items, by: { $0.type })
+		guard !receipt.items.isEmpty else { return [] }
+		let dictionaryByType = Dictionary(grouping: receipt.items, by: { $0.type })
 		let itemTypes = ReceiptItemType.allCases
 		return itemTypes.compactMap({ dictionaryByType[$0] })
 	}
 
 	var body: some View {
 		VStack(spacing: 0) {
-				Toggle(isOn: $isEnabled) {
-					Text(isEnabled ? Strings.ReceiptDetailView.onToggleTitle.string : Strings.ReceiptDetailView.defaultToggleTitle.string)
-						.font(.headline)
-				}
-				.toggleStyle(CustomToggleStyle())
-				.padding(.horizontal)
-				.padding(.bottom, 5)
+			Toggle(isOn: $isEnabled) {
+				Text(isEnabled ? Strings.ReceiptDetailView.onToggleTitle.string : Strings.ReceiptDetailView.defaultToggleTitle.string)
+					.font(.headline)
+			}
+			.toggleStyle(CustomToggleStyle())
+			.padding(.horizontal)
+			.padding(.bottom, 5)
 
 			GeometryReader { geometry in
 				List {

--- a/FairShare/UI/Receipt/ReceiptItemsView.swift
+++ b/FairShare/UI/Receipt/ReceiptItemsView.swift
@@ -7,39 +7,64 @@
 
 import SwiftUI
 
-//TODO: rename ReceiptTextView
 struct ReceiptItemsView: View {
-	@Binding var receiptTexts: [any ReceiptText]
+	let itemsByType: [[ReceiptItem]]
 	@Binding var isEditing: Bool
+	@Binding var receiptTexts: [any ReceiptText]
+	let itemTapped: (ReceiptItem) -> Void
 
-	var receiptItems: [ReceiptItem] {
-		receiptTexts.compactMap { $0 as? ReceiptItem }
-	}
+	let imageToDisplay: Image?
 
 	var body: some View {
-		List {
-			ForEach(receiptItems, id: \.id) { receiptItem in
-				if let index = receiptTexts.firstIndex(where: { $0.id == receiptItem.id }) {
-					if isEditing {
-						EditableReceiptItemView(item: Binding(
-							get: { receiptTexts[index] as! ReceiptItem },
-							set: { receiptTexts[index] = $0 }
-						))
-					} else {
-						HStack {
-							Text(receiptItem.title)
-							Spacer()
-							Text(receiptItem.costAsCurrency)
+		GeometryReader { geometry in
+			List {
+				ForEach(itemsByType, id: \.self) { itemInType in
+					Section(header: Text(itemInType[0].type.rawValue)) {
+						ForEach(itemInType) { item in
+							if let index = receiptTexts.firstIndex(where: { $0.id == item.id }) {
+								if isEditing {
+									EditableReceiptItemView(item: Binding(
+										get: { receiptTexts[index] as! ReceiptItem },
+										set: { receiptTexts[index] = $0 }
+									))
+								} else {
+									Button {
+										print(item.title)
+										itemTapped(item)
+									} label: {
+										HStack {
+											Text(item.title)
+											Spacer()
+											Text(item.costAsCurrency)
+										}
+									}
+								}
+							}
 						}
 					}
 				}
+				if let currentImage = imageToDisplay {
+					Section(header: Strings.ReceiptDetailView.imagesSectionTitle.text) {
+						HStack {
+							Spacer()
+							currentImage
+								.resizable()
+								.aspectRatio(contentMode: .fit)
+								.frame(width: geometry.size.width * 0.5, height: geometry.size.height * 0.5)
+							ShareLink(item: currentImage, preview: SharePreview("Current Image", image: currentImage))
+							Spacer()
+						}
+						.frame(height: geometry.size.height * 0.5)
+						.background(Color(.systemGray5))
+					}
+				}
 			}
+			.tint(Color.black)
 		}
+		.listSectionSpacing(0)
+		.navigationTitle(Strings.NewReceiptView.navigationTitle.text)
+		.navigationBarTitleDisplayMode(.inline)
 	}
 }
 
-#Preview {
-	ReceiptItemsView(receiptTexts: .constant([
-		ReceiptInformation(title: "Fruit Shop")] + ReceiptItem.dummyArrayData
-	), isEditing: .constant(true))
-}
+//TODO: Add Preview


### PR DESCRIPTION
In this PR I have (in order of commits):
- Added the ability to fetch `ReceiptItem` data from `Firestore Database`.
- Added the ability to display `ReceiptItem` data in `ReceiptDetailView`.
- Refactored code in `NewReceiptView` to use a `NewReceiptViewModel` to access all State variables.
- Added a `ContactModel` for storing `UserModel` contacts in `Firestore Database`.
- Added ability for user to save contacts in the `ProfileView`. To do so the user will access the `ContactPicker` which uses `CNContactPickerViewController` to open their phone's `Contacts` folder.
- Added the ability to fetch `ContactModel` data from `Firestore Database`. Ability to display or use this data will be added in a later PR.

`ReceiptDetailView` with live data, new `NewReceiptView` layout and `Add Contacts` demo (iPhone 15 Pro):

| Current | Previous |
| --- | --- |
| <img src="https://github.com/SLRAM/FairShare/assets/28938900/ffa88ecd-915d-4c53-a94c-42c59125e88b" width="184" height="400"> | <img src="https://github.com/SLRAM/FairShare/assets/28938900/b7e88fff-2456-4b6f-9139-b41457142c26" width="184" height="400"> |

Contacts `Firestore Database` Screenshot(Firebase):
<img src="https://github.com/SLRAM/FairShare/assets/28938900/dcca5637-f5c8-4b17-b617-d71a537a695a" width="1000" height="500">

Next Goals:
- Account for `TODO` notes in code.
- Finish updating error handling for `DBService`.
- Dismiss `NewReceiptView` if user cancels `CameraView` or `PhotosPicker`.
- Add `ContactModel` ids as payers to `ReceiptItem` and as a guests to `ReceiptModel`.