### PR TITLE
[Shared Payers]: add guests to ReceiptModel and tag ReceiptItems with shared payers

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -310,11 +310,11 @@
 		90FB961D2BF02BF60061E83D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				902C01FB2BF019770004B01A /* AuthViewModel.swift */,
+				9029DF172C314475008586E6 /* ContactModel.swift */,
 				90FB96142BF020490061E83D /* ReceiptModel.swift */,
 				90676E992C3A66ED00828276 /* ReceiptTextModel.swift */,
 				902C01FD2BF019B60004B01A /* UserModel.swift */,
-				9029DF172C314475008586E6 /* ContactModel.swift */,
-				902C01FB2BF019770004B01A /* AuthViewModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -358,10 +358,10 @@
 		90FB96222BF02D9A0061E83D /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				909E699D2C02C82A009D00D6 /* Color+Helper.swift */,
 				90FB96162BF023340061E83D /* Date+Helper.swift */,
 				90676E972C3A5CDA00828276 /* Double+Helper.swift */,
 				909E699B2C02C820009D00D6 /* Image+Helper.swift */,
-				909E699D2C02C82A009D00D6 /* Color+Helper.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		902C01FE2BF019B60004B01A /* UserModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902C01FD2BF019B60004B01A /* UserModel.swift */; };
 		902D77022C27766800F7B462 /* ReceiptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902D77012C27766800F7B462 /* ReceiptDetailView.swift */; };
 		902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902D77032C278D9400F7B462 /* CustomToggleStyle.swift */; };
+		90676E962C3A5C2600828276 /* ReceiptDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90676E952C3A5C2600828276 /* ReceiptDetailViewModel.swift */; };
+		90676E982C3A5CDA00828276 /* Double+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90676E972C3A5CDA00828276 /* Double+Helper.swift */; };
 		9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */; };
 		9072AFC72BE9C46E00DE6FEB /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC62BE9C46E00DE6FEB /* EntryView.swift */; };
 		9072AFC92BE9C47000DE6FEB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9072AFC82BE9C47000DE6FEB /* Assets.xcassets */; };
@@ -95,6 +97,8 @@
 		902C01FD2BF019B60004B01A /* UserModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserModel.swift; sourceTree = "<group>"; };
 		902D77012C27766800F7B462 /* ReceiptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptDetailView.swift; sourceTree = "<group>"; };
 		902D77032C278D9400F7B462 /* CustomToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggleStyle.swift; sourceTree = "<group>"; };
+		90676E952C3A5C2600828276 /* ReceiptDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptDetailViewModel.swift; sourceTree = "<group>"; };
+		90676E972C3A5CDA00828276 /* Double+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Helper.swift"; sourceTree = "<group>"; };
 		9072AFC12BE9C46E00DE6FEB /* FairShare.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FairShare.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FairShareApp.swift; sourceTree = "<group>"; };
 		9072AFC62BE9C46E00DE6FEB /* EntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryView.swift; sourceTree = "<group>"; };
@@ -260,6 +264,7 @@
 			children = (
 				902C01F92BF017660004B01A /* ReceiptView.swift */,
 				902D77012C27766800F7B462 /* ReceiptDetailView.swift */,
+				90676E952C3A5C2600828276 /* ReceiptDetailViewModel.swift */,
 				90F476202C1581950075B36B /* ReceiptCardView.swift */,
 				90FB96182BF029190061E83D /* NewReceiptView.swift */,
 				9029DF152C31422B008586E6 /* NewReceiptViewModel.swift */,
@@ -351,6 +356,7 @@
 			isa = PBXGroup;
 			children = (
 				90FB96162BF023340061E83D /* Date+Helper.swift */,
+				90676E972C3A5CDA00828276 /* Double+Helper.swift */,
 				909E699B2C02C820009D00D6 /* Image+Helper.swift */,
 				909E699D2C02C82A009D00D6 /* Color+Helper.swift */,
 			);
@@ -538,9 +544,11 @@
 				90FB96172BF023340061E83D /* Date+Helper.swift in Sources */,
 				909E69942C02A5C7009D00D6 /* CameraView.swift in Sources */,
 				909E69A02C02C865009D00D6 /* Constants.swift in Sources */,
+				90676E982C3A5CDA00828276 /* Double+Helper.swift in Sources */,
 				9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */,
 				902C01FA2BF017660004B01A /* ReceiptView.swift in Sources */,
 				902D77022C27766800F7B462 /* ReceiptDetailView.swift in Sources */,
+				90676E962C3A5C2600828276 /* ReceiptDetailViewModel.swift in Sources */,
 				90FB96272BF030B20061E83D /* LoginView.swift in Sources */,
 				9029DF162C31422B008586E6 /* NewReceiptViewModel.swift in Sources */,
 				9072AFD12BE9C47000DE6FEB /* FairShare.xcdatamodeld in Sources */,

--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		909E69A02C02C865009D00D6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699F2C02C865009D00D6 /* Constants.swift */; };
 		90BD783A2C0AEEB300C6A889 /* ReceiptItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */; };
 		90BD783C2C0C051E00C6A889 /* EditableReceiptItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */; };
+		90CA9FB92C396E11009F1251 /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90CA9FB82C396E11009F1251 /* SideMenuView.swift */; };
 		90F329842C1DB90D003AA887 /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F329832C1DB90D003AA887 /* StorageService.swift */; };
 		90F4761D2C14F6510075B36B /* DBService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F4761C2C14F6510075B36B /* DBService.swift */; };
 		90F4761F2C154FE20075B36B /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F4761E2C154FE20075B36B /* AuthService.swift */; };
@@ -112,6 +113,7 @@
 		909E699F2C02C865009D00D6 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptItemsView.swift; sourceTree = "<group>"; };
 		90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableReceiptItemView.swift; sourceTree = "<group>"; };
+		90CA9FB82C396E11009F1251 /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
 		90F329832C1DB90D003AA887 /* StorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageService.swift; sourceTree = "<group>"; };
 		90F4761C2C14F6510075B36B /* DBService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBService.swift; sourceTree = "<group>"; };
 		90F4761E2C154FE20075B36B /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
@@ -175,6 +177,7 @@
 			isa = PBXGroup;
 			children = (
 				902D77032C278D9400F7B462 /* CustomToggleStyle.swift */,
+				90CA9FB82C396E11009F1251 /* SideMenuView.swift */,
 			);
 			path = Elements;
 			sourceTree = "<group>";
@@ -513,6 +516,7 @@
 			files = (
 				9072AFCE2BE9C47000DE6FEB /* Persistence.swift in Sources */,
 				90FB96292BF0321C0061E83D /* InputView.swift in Sources */,
+				90CA9FB92C396E11009F1251 /* SideMenuView.swift in Sources */,
 				90F476212C1581950075B36B /* ReceiptCardView.swift in Sources */,
 				902C01FE2BF019B60004B01A /* UserModel.swift in Sources */,
 				902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */,

--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		902D77042C278D9400F7B462 /* CustomToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902D77032C278D9400F7B462 /* CustomToggleStyle.swift */; };
 		90676E962C3A5C2600828276 /* ReceiptDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90676E952C3A5C2600828276 /* ReceiptDetailViewModel.swift */; };
 		90676E982C3A5CDA00828276 /* Double+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90676E972C3A5CDA00828276 /* Double+Helper.swift */; };
+		90676E9A2C3A66ED00828276 /* ReceiptTextModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90676E992C3A66ED00828276 /* ReceiptTextModel.swift */; };
 		9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */; };
 		9072AFC72BE9C46E00DE6FEB /* EntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9072AFC62BE9C46E00DE6FEB /* EntryView.swift */; };
 		9072AFC92BE9C47000DE6FEB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9072AFC82BE9C47000DE6FEB /* Assets.xcassets */; };
@@ -99,6 +100,7 @@
 		902D77032C278D9400F7B462 /* CustomToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomToggleStyle.swift; sourceTree = "<group>"; };
 		90676E952C3A5C2600828276 /* ReceiptDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptDetailViewModel.swift; sourceTree = "<group>"; };
 		90676E972C3A5CDA00828276 /* Double+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Double+Helper.swift"; sourceTree = "<group>"; };
+		90676E992C3A66ED00828276 /* ReceiptTextModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptTextModel.swift; sourceTree = "<group>"; };
 		9072AFC12BE9C46E00DE6FEB /* FairShare.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FairShare.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9072AFC42BE9C46E00DE6FEB /* FairShareApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FairShareApp.swift; sourceTree = "<group>"; };
 		9072AFC62BE9C46E00DE6FEB /* EntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntryView.swift; sourceTree = "<group>"; };
@@ -309,6 +311,7 @@
 			isa = PBXGroup;
 			children = (
 				90FB96142BF020490061E83D /* ReceiptModel.swift */,
+				90676E992C3A66ED00828276 /* ReceiptTextModel.swift */,
 				902C01FD2BF019B60004B01A /* UserModel.swift */,
 				9029DF172C314475008586E6 /* ContactModel.swift */,
 				902C01FB2BF019770004B01A /* AuthViewModel.swift */,
@@ -529,6 +532,7 @@
 				9029DF142C3140A2008586E6 /* ContactPickerView.swift in Sources */,
 				90F5749F2BF93BCC005A9A2E /* MainTabView.swift in Sources */,
 				90FB96152BF020490061E83D /* ReceiptModel.swift in Sources */,
+				90676E9A2C3A66ED00828276 /* ReceiptTextModel.swift in Sources */,
 				90FB962F2BF0779B0061E83D /* SettingsRowView.swift in Sources */,
 				90F329842C1DB90D003AA887 /* StorageService.swift in Sources */,
 				902C01FC2BF019770004B01A /* AuthViewModel.swift in Sources */,

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -43,6 +43,7 @@ struct Images {
 		static let plus = ImageAsset(name: "plus", isSystem: true)
 		static let xMarkCircleFill = ImageAsset(name: "xmark.circle.fill", isSystem: true)
 		static let listBulletCircleFill = ImageAsset(name: "list.bullet.circle.fill", isSystem: true)
+		static let checkmarkCircle = ImageAsset(name: "checkmark.circle", isSystem: true)
 	}
 }
 
@@ -107,6 +108,11 @@ struct Strings {
 	struct ReceiptView {
 		static let navigationTitle = TextAsset(string: "Receipt History")
 		static let emptyState = TextAsset(string: "Click the + to add a new receipt")
+	}
+
+	struct SideMenuView {
+		static let viewTitle = TextAsset(string: "Select Sharers")
+		static let doneButton = TextAsset(string: "Done")
 	}
 }
 

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -76,6 +76,7 @@ struct Strings {
 	struct NewReceiptView {
 		static let navigationTitle = TextAsset(string: "New Receipt")
 		static let editButton = TextAsset(string: "Edit")
+		static let editDoneButton = TextAsset(string: "Edit Done")
 		static let saveButton = TextAsset(string: "Save")
 
 		static let cameraButton = "Camera"

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -137,6 +137,7 @@ struct Constants {
 		static let DateKey = "date"
 		static let ImageURLKey = "imageURL"
 		static let ItemsKey = "items"
+		static let GuestIDsKey = "guestIDs"
 	}
 
 	struct StorageKeys {

--- a/FairShare/Helpers/Extensions/Double+Helper.swift
+++ b/FairShare/Helpers/Extensions/Double+Helper.swift
@@ -1,0 +1,19 @@
+//
+//  Double+Helper.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 7/7/24.
+//
+
+import Foundation
+
+extension Double {
+	func currencyFormat() -> String {
+		String(format: "$%.02f", self)
+	}
+
+	func roundToDecimal(_ fractionDigits: Int) -> Double {
+		let multiplier = pow(10, Double(fractionDigits))
+		return Darwin.round(self * multiplier) / multiplier
+	}
+}

--- a/FairShare/Models/ContactModel.swift
+++ b/FairShare/Models/ContactModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ContactModel: Identifiable, Codable, Hashable {
+struct ContactModel: PayerProtocol {
 	var id: String
 	var firstName: String
 	var lastName: String

--- a/FairShare/Models/ReceiptTextModel.swift
+++ b/FairShare/Models/ReceiptTextModel.swift
@@ -1,0 +1,165 @@
+//
+//  ReceiptTextModel.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 7/7/24.
+//
+
+import Foundation
+
+protocol ReceiptText: Identifiable, Comparable {
+	var id: UUID { get }
+	var title: String { get set }
+
+	func toDictionary() -> [String: Any]
+}
+//TODO: Refactor name to account for multiple uses of "Item"
+enum ReceiptItemType: String, CaseIterable, Decodable {
+	case item
+	case subTotal
+	case tax
+	case tip
+	case total
+}
+
+class ReceiptItem: ReceiptText, Identifiable, Codable, Hashable {
+	let id: UUID
+	var title: String
+	var cost: Double
+	var payerIDs: [String]?
+	var type: ReceiptItemType
+
+	init(id: UUID = UUID(), title: String, cost: Double, payerIDs: [String] = [], type: ReceiptItemType = .item) {
+		self.id = id
+		self.title = title
+		self.cost = cost
+		self.payerIDs = payerIDs
+		self.type = type
+	}
+
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(id)
+	}
+
+	static func == (lhs: ReceiptItem, rhs: ReceiptItem) -> Bool {
+		return lhs.id == rhs.id && lhs.title == rhs.title && lhs.cost == rhs.cost
+	}
+
+	static func < (lhs: ReceiptItem, rhs: ReceiptItem) -> Bool {
+		return lhs.id < rhs.id
+	}
+
+	enum CodingKeys: String, CodingKey {
+		case id
+		case title
+		case cost
+		case payerIDs
+		case type
+	}
+
+	required init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		id = try container.decode(UUID.self, forKey: .id)
+		title = try container.decode(String.self, forKey: .title)
+		cost = try container.decode(Double.self, forKey: .cost)
+		payerIDs = try container.decodeIfPresent([String].self, forKey: .payerIDs)
+		type = try container.decode(ReceiptItemType.self, forKey: .type)
+	}
+
+	func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+		try container.encode(id, forKey: .id)
+		try container.encode(title, forKey: .title)
+		try container.encode(cost, forKey: .cost)
+		try container.encodeIfPresent(payerIDs, forKey: .payerIDs)
+		try container.encode(type.rawValue, forKey: .type)
+	}
+}
+
+extension ReceiptItem {
+	func costPerPayer(guestCount: Int) -> Double {
+		var count = 0
+
+		if let payerIDs = payerIDs, payerIDs.count > 0 {
+			count = payerIDs.count
+		} else {
+			count = guestCount + 1
+		}
+
+		let costPerPayer = cost / Double(count)
+
+		return costPerPayer
+	}
+
+	func toDictionary() -> [String: Any] {
+		var dictionary: [String: Any] = [
+			"id": id.uuidString,
+			"title": title,
+			"cost": cost,
+			"type": type.rawValue
+		]
+
+		if let payerIDs = payerIDs {
+			dictionary["payerIDs"] = payerIDs
+		}
+
+		return dictionary
+	}
+}
+
+extension ReceiptItem {
+	static let dummyData: ReceiptItem = dummyArrayData[0]
+	static let dummyArrayData: [ReceiptItem] = [
+		ReceiptItem(
+			title: "Apple",
+			cost: 1.99,
+			payerIDs: ContactModel.dummyArrayData.map { $0.id }
+		),
+		ReceiptItem(
+			title: "Banana",
+			cost: 0.99,
+			payerIDs: [ContactModel.dummyData.id]
+		),
+		ReceiptItem(
+			title: "Orange",
+			cost: 1.49
+		),
+		ReceiptItem(
+			title: "Tax",
+			cost: 0.40,
+			type: .tax
+		),
+		ReceiptItem(
+			title: "Total",
+			cost: 4.87,
+			type: .total
+		)
+	]
+}
+
+class ReceiptInformation: ReceiptText {
+	let id: UUID
+	var title: String
+
+	init(id: UUID = UUID(), title: String) {
+		self.id = id
+		self.title = title
+	}
+
+	static func == (lhs: ReceiptInformation, rhs: ReceiptInformation) -> Bool {
+		return lhs.id == rhs.id && lhs.title == rhs.title
+	}
+
+	static func < (lhs: ReceiptInformation, rhs: ReceiptInformation) -> Bool {
+		return lhs.id < rhs.id
+	}
+}
+
+extension ReceiptInformation {
+	func toDictionary() -> [String : Any] {
+		return [
+			"id": id.uuidString,
+			"title": title
+		]
+	}
+}

--- a/FairShare/Models/UserModel.swift
+++ b/FairShare/Models/UserModel.swift
@@ -7,15 +7,21 @@
 
 import Foundation
 
-struct UserModel: Identifiable, Codable, Hashable {
-	var id: String
-	var firstName: String
-	var lastName: String
-	var email: String
-	//TODO: add phone number.
+protocol PayerProtocol: Identifiable, Codable, Hashable {
+	var id: String { get }
+	var firstName: String { get }
+	var lastName: String { get }
 }
 
-extension UserModel {
+extension PayerProtocol {
+	var fullName: String {
+		"\(firstName) \(lastName)"
+	}
+
+	var abbreviatedName: String {
+		return "\(firstName) \(lastName.prefix(1))."
+	}
+
 	var initials: String {
 		let formatter = PersonNameComponentsFormatter()
 		if let components = formatter.personNameComponents(from: "\(firstName) \(lastName)") {
@@ -25,15 +31,17 @@ extension UserModel {
 
 		return ""
 	}
+}
 
-	var fullName: String {
-		return "\(firstName) \(lastName)"
-	}
+struct UserModel: PayerProtocol {
+	var id: String
+	var firstName: String
+	var lastName: String
+	var email: String
+	//TODO: add phone number.
+}
 
-	var abbreviatedName: String {
-		return "\(firstName) \(lastName.prefix(1))."
-	}
-
+extension UserModel {
 	static let dummyData: UserModel = dummyArrayData[0]
 	static let dummyArrayData: [UserModel] = [
 		UserModel(

--- a/FairShare/UI/Elements/SideMenuView.swift
+++ b/FairShare/UI/Elements/SideMenuView.swift
@@ -1,0 +1,84 @@
+//
+//  SideMenuView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 7/6/24.
+//
+
+import SwiftUI
+
+struct SideMenuView: View {
+	//TODO: add animation on Disappear. Create ViewModel.
+	@Binding var isShowing: Bool
+	@Binding var currentItem: ReceiptItem?
+	@Binding var availablePayers: [any PayerProtocol]
+	@Binding var currentGuestIDs: Set<String>
+	@State private var selectedPayerIDs: Set<String> = []
+
+	var body: some View {
+		ZStack {
+			if isShowing, let currentItem = currentItem  {
+				Color.black.opacity(0.3)
+					.edgesIgnoringSafeArea(.all)
+				VStack(spacing: 0) {
+					HStack(spacing: 0) {
+						Spacer()
+						Strings.SideMenuView.viewTitle.text
+							.font(.headline)
+						Spacer()
+					}
+					.padding()
+
+					List {
+						ForEach(availablePayers, id: \.id) { payer in
+							HStack {
+								Text(payer.abbreviatedName)
+								Spacer()
+								if selectedPayerIDs.contains(payer.id) {
+									Images.System.checkmarkCircle.image
+										.foregroundColor(.green)
+								}
+							}
+							.contentShape(Rectangle())
+							.onTapGesture {
+								if selectedPayerIDs.contains(payer.id) {
+									selectedPayerIDs.remove(payer.id)
+								} else {
+									selectedPayerIDs.insert(payer.id)
+								}
+							}
+						}
+					}
+
+					Button {
+						currentItem.payerIDs = Array(selectedPayerIDs)
+						self.currentItem = nil
+					} label: {
+						Strings.SideMenuView.doneButton.text
+							.frame(maxWidth: .infinity)
+							.padding()
+							.background(Color(.systemGray6))
+							.foregroundColor(.blue)
+							.cornerRadius(8)
+					}
+					.padding()
+				}
+				.onAppear {
+					if let payerIDs = currentItem.payerIDs {
+						selectedPayerIDs = Set(payerIDs)
+					}
+				}
+				.onDisappear {
+					//TODO: Account for when a user removes a guest. They should not be passed to currentGuestIDs if they are not listed on currentItem.payerIDs
+					currentGuestIDs.formUnion(selectedPayerIDs)
+				}
+				.background(Color.white)
+				.cornerRadius(12)
+				.padding()
+				.transition(.move(edge: .leading))
+			}
+		}
+	}
+}
+
+//TODO: Add Preview

--- a/FairShare/UI/Receipt/NewReceiptViewModel.swift
+++ b/FairShare/UI/Receipt/NewReceiptViewModel.swift
@@ -23,6 +23,8 @@ class NewReceiptViewModel: ObservableObject {
 	@Published var visualizedImage: UIImage?
 
 	@Published var isEnabled = false
+	@Published var selectedReceiptItem: ReceiptItem?
+	@Published var isSideMenuShowing = false
 
 	func itemsByType() -> [[ReceiptItem]] {
 		let receiptItems = receiptTexts.compactMap { $0 as? ReceiptItem }
@@ -49,7 +51,12 @@ class NewReceiptViewModel: ObservableObject {
 	}
 
 	func itemTapped(item: ReceiptItem) {
-		//TODO: select contact to add as payer.
-		print("Item tapped: \(item.title)")
+		if item.type == .item {
+			selectedReceiptItem = item
+		}
+	}
+
+	func contactsTapped(contactIds: [String]) {
+		selectedReceiptItem?.payerIDs = contactIds
 	}
 }

--- a/FairShare/UI/Receipt/ReceiptDetailViewModel.swift
+++ b/FairShare/UI/Receipt/ReceiptDetailViewModel.swift
@@ -1,0 +1,81 @@
+//
+//  ReceiptDetailViewModel.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 7/7/24.
+//
+
+import Foundation
+import SwiftUI
+
+class ReceiptDetailViewModel: ObservableObject {
+	var receipt: ReceiptModel
+	var userID: String
+
+	@Published var isEnabled = false
+	@Published var displayedGroupedItems: [[ReceiptItem]] = []
+	@Published private var groupedItems: [[ReceiptItem]] = []
+	@Published private var filteredGroupedItems: [[ReceiptItem]] = []
+
+	init(receipt: ReceiptModel, userID: String) {
+		self.receipt = receipt
+		self.userID = userID
+		setupInitialItems()
+	}
+
+	private var currentUserSubtotal: Double {
+		receipt.userSubtotal(userID: userID)
+	}
+
+	private var currentUserTax: Double {
+		receipt.userTaxTotal(userID: userID)
+	}
+
+	private var currentUserTotal: Double {
+		receipt.userTotal(userID: userID)
+	}
+
+	private var guestCount: Int {
+		receipt.guestIDs.count
+	}
+
+	private func setupInitialItems() {
+		groupedItems = groupItemsByType(items: receipt.items)
+		filteredGroupedItems = groupItemsByType(items: receipt.currentUserReceipt(userID: userID))
+		displayedGroupedItems = groupedItems
+	}
+
+	private func groupItemsByType(items: [ReceiptItem]) -> [[ReceiptItem]] {
+		guard !items.isEmpty else {
+			return []
+		}
+
+		let dictionaryByType = Dictionary(grouping: items, by: { $0.type })
+		let itemTypes = ReceiptItemType.allCases
+		return itemTypes.compactMap({ dictionaryByType[$0] })
+	}
+
+	func toggleEnabled() {
+		if isEnabled {
+			displayedGroupedItems = filteredGroupedItems
+		} else {
+			displayedGroupedItems = groupedItems
+		}
+	}
+
+	func formattedCost(for item: ReceiptItem) -> String {
+		switch item.type {
+		case .item:
+			return isEnabled ? item.costPerPayer(guestCount: guestCount).currencyFormat() : item.cost.currencyFormat()
+		case .subTotal:
+			return isEnabled ? currentUserSubtotal.currencyFormat() : item.cost.currencyFormat()
+		case .tax:
+			return isEnabled ? currentUserTax.currencyFormat() : item.cost.currencyFormat()
+		case .tip:
+			return item.cost.currencyFormat()
+		case .total:
+			return isEnabled ? currentUserTotal.currencyFormat() : item.cost.currencyFormat()
+
+		}
+	}
+}

--- a/FairShare/UI/Receipt/ReceiptItemsView.swift
+++ b/FairShare/UI/Receipt/ReceiptItemsView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct ReceiptItemsView: View {
+	//TODO: convert to viewModel
 	let itemsByType: [[ReceiptItem]]
 	@Binding var isEditing: Bool
 	@Binding var receiptTexts: [any ReceiptText]
@@ -35,7 +36,7 @@ struct ReceiptItemsView: View {
 										HStack {
 											Text(item.title)
 											Spacer()
-											Text(item.costAsCurrency)
+											Text(item.cost.currencyFormat())
 										}
 									}
 								}

--- a/FairShare/UI/Receipt/ReceiptView.swift
+++ b/FairShare/UI/Receipt/ReceiptView.swift
@@ -56,7 +56,13 @@ struct ReceiptView: View {
 				NewReceiptView()
 			}
 			.navigationDestination(for: ReceiptModel.self) { receipt in
-				ReceiptDetailView(receipt: receipt)
+				ReceiptDetailView(
+					viewModel:
+						ReceiptDetailViewModel(
+							receipt: receipt,
+							userID: authViewModel.currentUserID()
+						)
+				)
 			}
 		}
 	}


### PR DESCRIPTION
### Updates - In this PR I have (in order of commits):
- Refactored code to connect `ContactModel` and `UserModel` with a `PayerProtocol`. This will allow for easier access to the `id` values when storing `guestIDs` and `payerIDs`.
- Added a `SideMenuView` for selecting payers from contacts. Selected payers are added to the `ReceiptModel`  as `guestIDs` and to their respective `ReceiptItem`.
- Refactored code in `ReceiptDetailView` to use a `ReceiptDetailViewModel` to access all State variables.
- Added ability to view a receipt with only `ReceiptItems` that are connected to the current user in `ReceiptDetailView`.
- Refactored code in `ReceiptModel` to separate out `ReceiptText` into a new file.
- Refactored code to organize files by alphabetical order.
- Added the ability to save `guestIDs` from `ReceiptModel` and `payerIDs` from each `ReceiptItem` to `Firestore Database`.
- Added a `SideMenuView` to the `NewReceiptView` .

### Tag `ReceiptItem` and display solo receipt Demo (iPhone 15 Pro):
 <img src="https://github.com/SLRAM/FairShare/assets/28938900/87f30131-93ac-4fae-bb69-efea7db272aa" width="184" height="400">

**NOTE: Demo does not show flow for items that were never tagged. If a `ReceiptItem` is not tagged, it is assumed that every receipt guest will split the cost evenly. This is functional.**

## Next Goals:
- Account for `TODO` notes in code.
- Finish updating error handling for `DBService`.
- Dismiss `NewReceiptView` if user cancels `CameraView` or `PhotosPicker`.
- Add a way to distribute receipt information to guests that do not have the app. 
- Add guide frame to camera view. Only allow a photo to be taken when a receipt is properly centered.
- Allow user to take multiple photos for longer receipts.
- Move `confirmationDialog` from `NewReceiptView` to `ReceiptView`.