### PR TITLE
[MessageView] allow user to text guests their custom copy of the receipt

### DIFF
--- a/FairShare.xcodeproj/project.pbxproj
+++ b/FairShare.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		909E699C2C02C820009D00D6 /* Image+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699B2C02C820009D00D6 /* Image+Helper.swift */; };
 		909E699E2C02C82A009D00D6 /* Color+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699D2C02C82A009D00D6 /* Color+Helper.swift */; };
 		909E69A02C02C865009D00D6 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909E699F2C02C865009D00D6 /* Constants.swift */; };
+		90B98CC32C437B94006B6B83 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B98CC22C437B94006B6B83 /* MessageView.swift */; };
+		90B98CC52C439451006B6B83 /* String+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90B98CC42C439451006B6B83 /* String+Helper.swift */; };
 		90BD783A2C0AEEB300C6A889 /* ReceiptItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */; };
 		90BD783C2C0C051E00C6A889 /* EditableReceiptItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */; };
 		90CA9FB92C396E11009F1251 /* SideMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90CA9FB82C396E11009F1251 /* SideMenuView.swift */; };
@@ -117,6 +119,8 @@
 		909E699B2C02C820009D00D6 /* Image+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+Helper.swift"; sourceTree = "<group>"; };
 		909E699D2C02C82A009D00D6 /* Color+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Helper.swift"; sourceTree = "<group>"; };
 		909E699F2C02C865009D00D6 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		90B98CC22C437B94006B6B83 /* MessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
+		90B98CC42C439451006B6B83 /* String+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helper.swift"; sourceTree = "<group>"; };
 		90BD78392C0AEEB300C6A889 /* ReceiptItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptItemsView.swift; sourceTree = "<group>"; };
 		90BD783B2C0C051E00C6A889 /* EditableReceiptItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableReceiptItemView.swift; sourceTree = "<group>"; };
 		90CA9FB82C396E11009F1251 /* SideMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuView.swift; sourceTree = "<group>"; };
@@ -184,6 +188,7 @@
 			children = (
 				902D77032C278D9400F7B462 /* CustomToggleStyle.swift */,
 				90CA9FB82C396E11009F1251 /* SideMenuView.swift */,
+				90B98CC22C437B94006B6B83 /* MessageView.swift */,
 			);
 			path = Elements;
 			sourceTree = "<group>";
@@ -362,6 +367,7 @@
 				90FB96162BF023340061E83D /* Date+Helper.swift */,
 				90676E972C3A5CDA00828276 /* Double+Helper.swift */,
 				909E699B2C02C820009D00D6 /* Image+Helper.swift */,
+				90B98CC42C439451006B6B83 /* String+Helper.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -536,6 +542,7 @@
 				90FB962F2BF0779B0061E83D /* SettingsRowView.swift in Sources */,
 				90F329842C1DB90D003AA887 /* StorageService.swift in Sources */,
 				902C01FC2BF019770004B01A /* AuthViewModel.swift in Sources */,
+				90B98CC32C437B94006B6B83 /* MessageView.swift in Sources */,
 				909E699C2C02C820009D00D6 /* Image+Helper.swift in Sources */,
 				90FB96312BF08C240061E83D /* FirebaseErrors.swift in Sources */,
 				90FB96192BF029190061E83D /* NewReceiptView.swift in Sources */,
@@ -547,6 +554,7 @@
 				90F4761F2C154FE20075B36B /* AuthService.swift in Sources */,
 				90FB96172BF023340061E83D /* Date+Helper.swift in Sources */,
 				909E69942C02A5C7009D00D6 /* CameraView.swift in Sources */,
+				90B98CC52C439451006B6B83 /* String+Helper.swift in Sources */,
 				909E69A02C02C865009D00D6 /* Constants.swift in Sources */,
 				90676E982C3A5CDA00828276 /* Double+Helper.swift in Sources */,
 				9072AFC52BE9C46E00DE6FEB /* FairShareApp.swift in Sources */,

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -115,6 +115,12 @@ struct Strings {
 		static let viewTitle = TextAsset(string: "Select Sharers")
 		static let doneButton = TextAsset(string: "Done")
 	}
+
+	struct MessageView {
+		static let typeIdentifier = TextAsset(string: "public.data")
+		static let fileName = TextAsset(string: "image")
+		static let fileType = TextAsset(string: ".jpg")
+	}
 }
 
 struct Constants {

--- a/FairShare/Helpers/Constants.swift
+++ b/FairShare/Helpers/Constants.swift
@@ -44,6 +44,7 @@ struct Images {
 		static let xMarkCircleFill = ImageAsset(name: "xmark.circle.fill", isSystem: true)
 		static let listBulletCircleFill = ImageAsset(name: "list.bullet.circle.fill", isSystem: true)
 		static let checkmarkCircle = ImageAsset(name: "checkmark.circle", isSystem: true)
+		static let arrowUpMessage = ImageAsset(name: "arrow.up.message", isSystem: true)
 	}
 }
 
@@ -104,6 +105,8 @@ struct Strings {
 		static let defaultToggleTitle = TextAsset(string: "Full Receipt")
 		static let onToggleTitle = TextAsset(string: "Self Only")
 		static let imagesSectionTitle = TextAsset(string: "Images")
+		static let guestListTitle = TextAsset(string: "Send Guest Copies")
+		static let receiptImage = TextAsset(string: "Receipt created on ")
 	}
 
 	struct ReceiptView {

--- a/FairShare/Helpers/Extensions/String+Helper.swift
+++ b/FairShare/Helpers/Extensions/String+Helper.swift
@@ -1,0 +1,33 @@
+//
+//  String+Helper.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 7/14/24.
+//
+
+import Foundation
+import UIKit
+
+extension String {
+//https://stackoverflow.com/questions/51100121/how-to-generate-an-uiimage-from-custom-text-in-swift
+	/// Generates a `UIImage` instance from this string using a specified
+	/// attributes and size.
+	///
+	/// - Parameters:
+	///     - attributes: to draw this string with. Default is `nil`.
+	///     - size: of the image to return.
+	/// - Returns: a `UIImage` instance from this string using a specified
+	/// attributes and size, or `nil` if the operation fails.
+	func image(withAttributes attributes: [NSAttributedString.Key: Any]? = nil, size: CGSize? = nil) -> UIImage? {
+		let size = size ?? (self as NSString).size(withAttributes: attributes)
+		return UIGraphicsImageRenderer(size: size)
+			.image { _ in
+				(self as NSString)
+					.draw(
+						in: CGRect(origin: CGPoint(x: 5, y: 0), size: size),
+						withAttributes: attributes
+					)
+			}
+	}
+
+}

--- a/FairShare/Models/AuthViewModel.swift
+++ b/FairShare/Models/AuthViewModel.swift
@@ -19,6 +19,7 @@ class AuthViewModel: ObservableObject {
 	@Published var isLoading: Bool = true
 	@Published var availablePayers: [any PayerProtocol] = []
 	@Published var currentGuestIDs: Set<String> = []
+	@Published var fetchedReceiptGuests: [ContactModel] = []
 
 	init() {
 		self.userSession = AuthService.CurrentUser
@@ -37,6 +38,7 @@ class AuthViewModel: ObservableObject {
 extension AuthViewModel {
 	func currentUserID() -> String {
 		guard let userID = self.currentUser?.id else {
+			//TODO: signout user?
 			print("Error: Current user ID is nil.")
 			return ""
 		}
@@ -166,6 +168,17 @@ extension AuthViewModel {
 
 			availablePayers = payerList.sorted { $0.firstName < $1.firstName }
 
+		} catch {
+			print("Error fetching user contacts: \(error)")
+			throw error
+		}
+	}
+
+	func fetchCurrentReceiptGuests(for receipt: ReceiptModel) async throws {
+		do {
+			let fetchedGuests = try await DBService.fetchReceiptGuests(userID: currentUserID(), contactIDs: receipt.guestIDs)
+
+			fetchedReceiptGuests = fetchedGuests.sorted { $0.firstName < $1.firstName }
 		} catch {
 			print("Error fetching user contacts: \(error)")
 			throw error

--- a/FairShare/Models/ReceiptTextModel.swift
+++ b/FairShare/Models/ReceiptTextModel.swift
@@ -17,6 +17,7 @@ protocol ReceiptText: Identifiable, Comparable {
 enum ReceiptItemType: String, CaseIterable, Decodable {
 	case item
 	case subTotal
+	case service
 	case tax
 	case tip
 	case total

--- a/FairShare/UI/Elements/MessageView.swift
+++ b/FairShare/UI/Elements/MessageView.swift
@@ -1,0 +1,57 @@
+//
+//  MessageView.swift
+//  FairShare
+//
+//  Created by Stephanie Ramirez on 7/13/24.
+//
+
+import SwiftUI
+import MessageUI
+import Messages
+
+struct MessageComposeView: UIViewControllerRepresentable {
+	var recipients: [String]
+	var body: String
+	var images: [UIImage]?
+
+	@Environment(\.presentationMode) private var presentationMode
+
+	class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
+		var parent: MessageComposeView
+
+		init(_ parent: MessageComposeView) {
+			self.parent = parent
+		}
+
+		func messageComposeViewController(_ controller: MFMessageComposeViewController, didFinishWith result: MessageComposeResult) {
+			parent.presentationMode.wrappedValue.dismiss()
+		}
+	}
+
+	func makeCoordinator() -> Coordinator {
+		Coordinator(self)
+	}
+
+	func makeUIViewController(context: Context) -> MFMessageComposeViewController {
+		let controller = MFMessageComposeViewController()
+		controller.messageComposeDelegate = context.coordinator
+		controller.recipients = recipients
+		controller.body = body
+
+		if let images = images {
+			for (index, image) in images.enumerated() {
+				if let imageData = image.jpegData(compressionQuality: 1.0) {
+					controller.addAttachmentData(imageData, typeIdentifier: Strings.MessageView.typeIdentifier.string, filename: Strings.MessageView.fileName.string + "\(index + 1)" + Strings.MessageView.fileType.string)
+				}
+			}
+		}
+
+		return controller
+	}
+
+	func updateUIViewController(_ uiViewController: MFMessageComposeViewController, context: Context) {}
+
+	public static func canSendText() -> Bool {
+		MFMessageComposeViewController.canSendText()
+	}
+}

--- a/FairShare/UI/Profile/ContactPickerView.swift
+++ b/FairShare/UI/Profile/ContactPickerView.swift
@@ -10,6 +10,7 @@ import ContactsUI
 import SwiftUI
 
 struct ContactPickerView: UIViewControllerRepresentable {
+	//TODO: add searchbar and guard for adding self.
 	@Binding var selectedContacts: [ContactModel]
 
 	func makeUIViewController(context: Context) -> CNContactPickerViewController {

--- a/FairShare/UI/Receipt/NewReceiptView.swift
+++ b/FairShare/UI/Receipt/NewReceiptView.swift
@@ -10,6 +10,7 @@ import PhotosUI
 import SwiftUI
 
 struct NewReceiptView: View {
+	//TODO: create a add guests option for receipts where everything is split.
 	@Environment(\.dismiss) var dismiss
 	@EnvironmentObject var authViewModel: AuthViewModel
 	@StateObject private var viewModel = NewReceiptViewModel()

--- a/FairShare/UI/Receipt/ReceiptDetailView.swift
+++ b/FairShare/UI/Receipt/ReceiptDetailView.swift
@@ -6,9 +6,11 @@
 //
 
 import SwiftUI
+import MessageUI
 
 struct ReceiptDetailView: View {
 	@ObservedObject var viewModel: ReceiptDetailViewModel
+	@Binding var guests: [ContactModel]
 
 	var body: some View {
 		VStack(spacing: 0) {
@@ -54,11 +56,26 @@ struct ReceiptDetailView: View {
 									EmptyView()
 								}
 							}
-
 							Spacer()
 						}
 						.frame(height: geometry.size.height * 0.5)
 						.background(Color(.systemGray5))
+					}
+
+					Section(header: Strings.ReceiptDetailView.guestListTitle.text) {
+						ForEach(guests, id: \.self) { guest in
+							Button {
+								viewModel.selectedGuest = guest
+								viewModel.showMessageComposeView = true
+							} label: {
+								HStack {
+									Text(guest.abbreviatedName)
+										.foregroundStyle(.black)
+									Spacer()
+									Images.System.arrowUpMessage.image
+								}
+							}
+						}
 					}
 				}
 				.listSectionSpacing(0)
@@ -66,10 +83,15 @@ struct ReceiptDetailView: View {
 				.navigationBarTitleDisplayMode(.inline)
 			}
 		}
+		.sheet(isPresented: $viewModel.showMessageComposeView) {
+			if let phoneNumber = viewModel.selectedGuest?.phoneNumber, MessageComposeView.canSendText() {
+				MessageComposeView(recipients: [phoneNumber], body: Strings.ReceiptDetailView.receiptImage.string + viewModel.receipt.date.toString(), images: viewModel.guestReceiptImages())
+				}
+		}
 	}
 }
 
 
 #Preview {
-	ReceiptDetailView(viewModel: ReceiptDetailViewModel(receipt: ReceiptModel.dummyData, userID: UserModel.dummyData.id))
+	ReceiptDetailView(viewModel: ReceiptDetailViewModel(receipt: ReceiptModel.dummyData, userID: UserModel.dummyData.id), guests: .constant(ContactModel.dummyArrayData))
 }

--- a/FairShare/UI/Receipt/ReceiptDetailViewModel.swift
+++ b/FairShare/UI/Receipt/ReceiptDetailViewModel.swift
@@ -17,6 +17,9 @@ class ReceiptDetailViewModel: ObservableObject {
 	@Published private var groupedItems: [[ReceiptItem]] = []
 	@Published private var filteredGroupedItems: [[ReceiptItem]] = []
 
+	@Published var showMessageComposeView = false
+	@Published var selectedGuest: ContactModel?
+
 	init(receipt: ReceiptModel, userID: String) {
 		self.receipt = receipt
 		self.userID = userID

--- a/FairShare/UI/Receipt/ReceiptDetailViewModel.swift
+++ b/FairShare/UI/Receipt/ReceiptDetailViewModel.swift
@@ -38,6 +38,10 @@ class ReceiptDetailViewModel: ObservableObject {
 		receipt.userTotal(userID: userID)
 	}
 
+	private var currentUserServiceTotal: Double {
+		receipt.userServiceTotal(userID: userID)
+	}
+
 	private var guestCount: Int {
 		receipt.guestIDs.count
 	}
@@ -78,6 +82,11 @@ class ReceiptDetailViewModel: ObservableObject {
 			return item.cost.currencyFormat()
 		case .total:
 			return isEnabled ? currentUserTotal.currencyFormat() : item.cost.currencyFormat()
+		case .service:
+			return isEnabled ? currentUserServiceTotal.currencyFormat() : item.cost.currencyFormat()
+
+		}
+	}
 
 	func guestReceiptImages() -> [UIImage]? {
 		if let guestReceiptDescription = guestReceiptDescription(), let receiptDescription = receiptDescription() {

--- a/FairShare/UI/Receipt/ReceiptItemsView.swift
+++ b/FairShare/UI/Receipt/ReceiptItemsView.swift
@@ -15,6 +15,13 @@ struct ReceiptItemsView: View {
 	let itemTapped: (ReceiptItem) -> Void
 
 	let imageToDisplay: Image?
+	private func deleteItems(at offsets: IndexSet, from itemInType: [ReceiptItem]) {
+		for index in offsets {
+			if let globalIndex = receiptTexts.firstIndex(where: { $0.id == itemInType[index].id }) {
+				receiptTexts.remove(at: globalIndex)
+			}
+		}
+	}
 
 	var body: some View {
 		GeometryReader { geometry in
@@ -42,8 +49,12 @@ struct ReceiptItemsView: View {
 								}
 							}
 						}
+						.onDelete { indexSet in
+							deleteItems(at: indexSet, from: itemInType)
+						}
 					}
 				}
+
 				if let currentImage = imageToDisplay {
 					Section(header: Strings.ReceiptDetailView.imagesSectionTitle.text) {
 						HStack {

--- a/FairShare/UI/Receipt/ReceiptView.swift
+++ b/FairShare/UI/Receipt/ReceiptView.swift
@@ -61,8 +61,14 @@ struct ReceiptView: View {
 						ReceiptDetailViewModel(
 							receipt: receipt,
 							userID: authViewModel.currentUserID()
-						)
+						),
+					guests: $authViewModel.fetchedReceiptGuests
 				)
+				.onAppear {
+					Task {
+						try await authViewModel.fetchCurrentReceiptGuests(for: receipt)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Updates - In this PR I have (in order of commits):
- Created a `MessageView` to allow for sending text message with receipt information.
- Created helper functions to convert receipt data into an Image. This image will be sent in the `MessageView` to the selected guest.
- Added the ability to delete unwanted `ReceiptItem` data from a new receipt.
- Added ability to fetch a receipt guest's `ContactModel` data from `Firestore Database`.
- Added the ability to display a list of receipt guests and text them their version of the receipt within the `ReceiptDetailView`.
- Refactored code in `ReceiptModel` to account for service fees listed on a receipt.

### Guest List (iPhone 11):
 <img src="https://github.com/user-attachments/assets/0c4b23fa-79af-4db8-9a9f-eb0ccd82275c" width="184" height="400">

### Guest Text (iPhone 11):
 <img src="https://github.com/user-attachments/assets/53026952-3d0b-47b2-b069-11400499bbaa" width="184" height="400">

### Guest images sent:
<kbd>
  <img src="https://github.com/user-attachments/assets/e28bb549-3c30-4ea6-80bc-181700ea3656" width="300" height="300">
</kbd>

<kbd>
  <img src="https://github.com/user-attachments/assets/7c93c790-9839-4f0c-9f95-b2f3c28e3603" width="300" height="300">
</kbd>
